### PR TITLE
Fix for text id object insertion issue

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -195,6 +195,7 @@ MongoDB.prototype.save = function (model, data, callback) {
   var idName = self.idName(model);
 
   var oid = ObjectID(idValue);
+  data._id = oid;
   delete data[idName];
 
   this.collection(model).update({_id: oid}, data, {safe: true, upsert: true}, function (err, result) {


### PR DESCRIPTION
Mongodb connector uses an `save/upsert` operation to insert new document, with the following code :

```
  var oid = ObjectID(idValue);
  delete data[idName];
  this.collection(model).update({_id: oid}, data, {safe: true, upsert: true}, function (
```

The data yet to be inserted does not contains an `_id` property, and the regular `id` is deleted, so the final object in the database will have a mongodb-generated id, even when a string id was provided.

(behaviour with mongod v2.4.9)

Here is a fix that makes sure user-defined id is set as mongo _id : 

```
  var oid = ObjectID(idValue);
  data._id = oid;
  delete data[idName];
  this.collection(model).update({_id: oid}, data, {safe: true, upsert: true}, function (
```

By manually adding the provided `id` to the data to insert, we make it possible to attain the database.
