### PR TITLE
Do not return MongoDB-specific _id to client API, except if specified in model definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,28 @@ To use it you need `loopback-datasource-juggler@1.0.x`.
         ...
     ```
 
-## About MongoDB ID field
+
+### About MongoDB _id field
 
 MongoDB uses a specific ID field with BSON `ObjectID` type, named `_id`
 
-This connector does not expose this `_id` by default, to keep consistency with other connectors.
+This connector does not expose MongoDB `_id` by default, to keep consistency with other connectors. Instead, it is transparently mapped to the `id` field - which is declared by default in the model if you do not define any `id`. 
 
-Default ID field keeps MongoDB `ObjectID` type, but field name is `id`, or any other field name specified in the loopback model's definition.
-
-If you want to use the original MongoDB `_id` field in your loopback model, please explicitly specify the type **DataSource.ObjectID** / **MongoDB.ObjectID** type in your model's definition.
+If you wish to still be able to access `_id` property, you must define it explicitely as your model ID, along with its type.
 
 *Example :*
 
     var ds = app.dataSources.db;
-    MyModel = ds.createModel('mymodel', {_id: ds.ObjectID});
+    MyModel = ds.createModel('mymodel', {
+        _id: { type: ds.ObjectID, id: true }
+    });
+
+*Example with a Number _id :
+
+    MyModel = ds.createModel('mymodel', {
+        _id: { type: Number, id: true }
+    });
+
 
 ## Customizing MongoDB configuration for tests/examples
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -120,50 +120,6 @@ MongoDB.prototype.connect = function (callback) {
   }
 };
 
-/**
- * Hook the setter if model use MongoDB _id property as ID
- * @param {Object} modelDefinition The model definition
- */
-MongoDB.prototype.define = function (modelDefinition) {
-  var _idIsModelID = modelDefinition && 
-                     modelDefinition.properties && 
-                     modelDefinition.properties._id && 
-                     modelDefinition.properties._id.id;
-  if (_idIsModelID) {
-    if (modelDefinition.properties._id.type !== this.dataSource.ObjectID) {
-      throw new Error('To use MongoDB _id as loopback model ID ' +
-                   'please use type [MongoDB|DataSource].ObjectID ' +
-                   'instead of ' + modelDefinition.properties._id.type);
-    }
-    modelDefinition.model.setter._id = function(id) {
-      if ((id instanceof this.getDataSource().ObjectID)) return id;
-      return this.getDataSource().ObjectID(id);
-    }
-  }
-  return Connector.prototype.define.call(this, modelDefinition);
-};
-
-/**
- * Hook the setter if model use MongoDB _id property as ID
- * @param {String} model The model name
- * @param {String} propertyName The property name
- * @param {Object} propertyDefinition The object for property metadata
- */
-MongoDB.prototype.defineProperty = function (model, propertyName, propertyDefinition) {
-  if (propertyName = '_id' && propertyDefinition.id) {
-    if (propertyDefinition.type !== this.dataSource.ObjectID) {
-      throw new Error('To use MongoDB _id as loopback model ID ' +
-                   'please use type [MongoDB|DataSource].ObjectID ' +
-                   'instead of ' + propertyDefinition.type);
-    }
-    this._models[model].model.setter._id = function(id) {
-      if ((id instanceof this.getDataSource().ObjectID)) return id;
-      return this.getDataSource().ObjectID(id);
-    }
-  }
-  return Connector.prototype.defineProperty.call(this, model, propertyName, propertyDefinition);
-};
-
 MongoDB.prototype.getTypes = function () {
   return ['db', 'nosql', 'mongodb'];
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-mongodb",
-  "version": "1.1.7",
+  "version": "1.1.6",
   "description": "LoopBack MongoDB Connector",
   "keywords": [ "StrongLoop", "LoopBack", "MongoDB", "DataSource", "Connector" ],
   "main": "index.js",


### PR DESCRIPTION
As discussed in the Google Group, here is a PR that removes mongodb-specific `_id` from API exposition.

The main issue about this, other than having client-side model having to deal with unexpected `_id` attribute, is that when making a PUT with the same object, hence with `_id` included, it triggers a MongoDB exception, because it does not accept modifications of `_id` property.

After this commit, only the ID specified in the model definition will be returned, beeing `id` or another specified name. 

**Note** : As explained in the `README.md`, I added the possibility to still rely on MongoDB `_id` attribute in the loopback model, as I suspect that some might need it, but in this case, it needs to be explicitly defined in the model definition, with `ObjectID` type. Example :

```
var ds = app.dataSources.db;
MyModel = ds.createModel('mymodel', {_id: ds.ObjectID});
```

This possibility required to add a property setter for the property named `_id`, because the default behaviour of the property setter in the model builder is to use the type as a caster :

```
property = DataType(value);
```

The main problem is that MongoDB javascript BSON ObjectID type cannot cast itself ! It will throw an error.

The custom MongoDB connector setter will take care of this issue by calling ObjectID only if value is not already instance of it.

I implemented this setter in two model definition hooks : `Connector.prototype.define` and `Connector.prototype.defineProperty`. If there are additional ways to set the ID property, they also should be hooked to in order to enable the custom setter.

I also added a bunch of tests to double check that all behaviour work with models with `_id` or other type of IDs, and updated `README.md`
