### PR TITLE
Added options to like/nlike operator to allow for regex flags

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -403,7 +403,9 @@ function buildWhere(where) {
       return;
     }
     var spec = false;
+    var options = null;
     if (cond && cond.constructor.name === 'Object') {
+      options = cond.options;
       spec = Object.keys(cond)[0];
       cond = cond[spec];
     }
@@ -416,9 +418,9 @@ function buildWhere(where) {
           return ObjectID(x);
         })};
       } else if (spec === 'like') {
-        query[k] = {$regex: new RegExp(cond)};
+        query[k] = {$regex: new RegExp(cond, options)};
       } else if (spec === 'nlike') {
-        query[k] = {$not: new RegExp(cond)};
+        query[k] = {$not: new RegExp(cond, options)};
       }
       else {
         query[k] = {};

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -477,6 +477,16 @@ describe('mongodb', function () {
     });
   });
 
+  it('should allow to find using case insensitive like', function (done) {
+    Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
+      Post.find({where: {title: {like: 'm.+st', options: 'i'}}}, function (err, posts) {
+        should.not.exist(err);
+        posts.should.have.property('length', 1);
+        done();
+      });
+    });
+  });
+
   it('should support like for no match', function (done) {
     Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
       Post.find({where: {title: {like: 'M.+XY'}}}, function (err, posts) {
@@ -490,6 +500,16 @@ describe('mongodb', function () {
   it('should allow to find using nlike', function (done) {
     Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
       Post.find({where: {title: {nlike: 'M.+st'}}}, function (err, posts) {
+        should.not.exist(err);
+        posts.should.have.property('length', 0);
+        done();
+      });
+    });
+  });
+
+  it('should allow to find using case insensitive nlike', function (done) {
+    Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
+      Post.find({where: {title: {nlike: 'm.+st', options: 'i'}}}, function (err, posts) {
         should.not.exist(err);
         posts.should.have.property('length', 0);
         done();


### PR DESCRIPTION
Not sure if there's a cleaner way to do this. Basically just added the ability to specify Regex flags so that case insensitive search can be done.

Format would be:
```
Post.find({
  where: {
    title: {
      like: 'someth.*',
      options: 'i'
    }
  }
});
```