### PR TITLE
Remove peer dependency on datasource-juggler

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -4,7 +4,7 @@
 var mongodb = require('mongodb');
 var util = require('util');
 var async = require('async');
-var Connector = require('loopback-datasource-juggler').Connector;
+var Connector = require('loopback-connector').Connector;
 var debug = require('debug')('loopback:connector:mongodb');
 
 /*!

--- a/package.json
+++ b/package.json
@@ -14,12 +14,10 @@
     "test": "make test"
   },
   "dependencies": {
+    "loopback-connector": "1.x",
     "mongodb": "~1.4.3",
     "async": "~0.9.0",
     "debug": "~0.8.1"
-  },
-  "peerDependencies": {
-    "loopback-datasource-juggler": "1.x.x"
   },
   "devDependencies": {
     "loopback-datasource-juggler": "1.x.x",


### PR DESCRIPTION
Use `Connector` from `loopback-connector` as the base class for the
MongoDB connector.

Note: the behaviour remains backwards compatible, the connector can be
used with both old 1.x and upcoming 2.x versions of
loopback-datasource-juggler

/to @raymondfeng @ritch please review.

strongloop/loopback#275
