### PR TITLE
allows for different kind of indexes

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -717,14 +717,28 @@ MongoDB.prototype.autoupdate = function (models, cb) {
           index = {};
           index[p] = 1; // Add the index key
           if (typeof properties[p].index === 'object') {
-            // The index value should be the options
-            options = properties[p].index;
-            if(options.background === undefined) {
+            // If there is a mongodb key for the index, use it
+            if (typeof properties[p].index.mongodb === 'object') {
+              options = properties[p].index.mongodb;
+              index[p] = options.kind || 1;
+
+              // Backwards compatibility for former type of indexes
+              if (properties[p].index.unique === true) {
+                options.unique = true;
+              }
+
+            } else {
+              // If there isn't an  properties[p].index.mongodb object, we read the properties from  properties[p].index
+              options = properties[p].index;
+            }
+
+            if (options.background === undefined) {
               options.background = true;
             }
+          // If properties[p].index isn't an object we hardcode the background option and check for properties[p].unique
           } else {
             options = {background: true};
-            if(p.unique) {
+            if(properties[p].unique) {
               options.unique = true;
             }
           }

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1,7 +1,7 @@
 // This test written in mocha+should.js
 var should = require('./init.js');
 
-var User, Post, PostWithStringId, db;
+var Superhero, User, Post, PostWithStringId, db;
 
 describe('mongodb', function () {
 
@@ -20,6 +20,16 @@ describe('mongodb', function () {
         }, // The value contains keys and optinally options
         age_index: {age: -1} // The value itself is for keys
       }
+    });
+
+    Superhero = db.define('Superhero', {
+      name: { type: String, index: true },
+      power: { type: String, index: true, unique: true },
+      address: { type: String, required: false, index: { mongodb: { unique: false, sparse: true } } },
+      description: { type: String, required: false },
+      geometry: { type: Object, required: false, index: { mongodb: { kind: "2dsphere" } } },
+      age: Number,
+      icon: Buffer
     });
 
     Post = db.define('Post', {
@@ -105,6 +115,23 @@ describe('mongodb', function () {
           age_index: [ [ 'age', -1 ] ],
           name_1: [ [ 'name', 1 ] ],
           email_1: [ [ 'email', 1 ] ] };
+
+        indexes.should.eql(result);
+        done(err, result);
+      });
+    });
+  });
+
+  it('should create complex indexes', function (done) {
+    db.automigrate('Superhero', function () {
+      db.connector.db.collection('Superhero').indexInformation(function (err, result) {
+
+        var indexes =
+        { _id_: [ [ '_id', 1 ] ],
+          geometry_2dsphere: [ [ 'geometry', '2dsphere' ] ],
+          power_1: [ [ 'power', 1 ] ],
+          name_1: [ [ 'name', 1 ] ],
+          address_1: [ [ 'address', 1 ] ] };
 
         indexes.should.eql(result);
         done(err, result);


### PR DESCRIPTION
Let's say you had a mongodb model with properties

```
   "properties" : {
 				"id": {
 					"type": "String",
 					"required": false,
 					"id": 1
 				},
 				"geometry": {
 					"type": "Object",
 					"required": false,
 					"index": {
 						"unique": true
 					}
 				}
 			};
```

when you run autoupdate on this model, it will execute 

```
db[collection].ensureIndex({"geometry":1},{"unique":true});
```
the **1** (which stands for a regular index in natural order) is hardcoded. This pull request let's you create other kind of indexes

For example, to create a ["2dsphere" index](http://docs.mongodb.org/manual/tutorial/build-a-2dsphere-index/), the model properties should be 

```
   "properties" : {
 				"id": {
 					"type": "String",
 					"required": false,
 					"id": 1
 				},
 				"geometry": {
 					"type": "Object",
 					"required": false,
 					"index": {
 						"kind": "2dsphere"
 					}
 				}
 			};
```

and this will execute

```
db[collection].ensureIndex({"geometry":"2dsphere"});
```

I used the "kind" attribute to be consistent with loopback-mysql-connector. Besides 2dsphere indexes, you can also create [2d](http://docs.mongodb.org/manual/core/2d/), [text](http://docs.mongodb.org/manual/core/index-text/) and [geoHaystack](http://docs.mongodb.org/manual/core/geohaystack/) indexes.

