### PR TITLE
Support for geoNear queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ instance running on localhost at port 27017.
 To customize the settings, you can drop in a `.loopbackrc` file to the root directory
 of the project or the home folder.
 
-**Note**: Tests and examples in this project configure the data source using the deprecated '.loopbackrc' file method, 
+**Note**: Tests and examples in this project configure the data source using the deprecated '.loopbackrc' file method,
 which is not suppored in general.
 For information on configuring the connector in a LoopBack application, please refer to [LoopBack documentation](http://docs.strongloop.com/display/LB/MongoDB+connector).
 
@@ -42,12 +42,15 @@ The .loopbackrc file is in JSON format, for example:
 **Note**: username/password is only required if the MongoDB server has
 authentication enabled.
 
-###Additional Settings 
+###Additional Settings
 
-allowExtendedOperators - ```false``` by default, ```true``` allows to use mongo operators like 
-```$currentDate, $inc, $max, $min, $mul, $rename, $setOnInsert, $set, $unset, $addToSet, 
+allowExtendedOperators - ```false``` by default, ```true``` allows to use mongo operators like
+```$currentDate, $inc, $max, $min, $mul, $rename, $setOnInsert, $set, $unset, $addToSet,
 $pop, $pullAll, $pull, $pushAll, $push,  $bit ```.
 
+
+enableGeoIndexing - ```false``` by default, ```true``` enables 2dsphere indexing for model properties
+of type ```GeoPoint```. This allows for indexed ```near``` queries etc.
 
 ## Running tests
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -93,6 +93,11 @@ function MongoDB(settings, dataSource) {
     this.settings.enableOptimizedFindOrCreate === true) {
     MongoDB.prototype.findOrCreate = optimizedFindOrCreate;
   }
+  if (this.settings.enableGeoIndexing === true) {
+    MongoDB.prototype.buildNearFilter = buildNearFilter;
+  } else {
+    MongoDB.prototype.buildNearFilter = undefined;
+  }
 }
 
 util.inherits(MongoDB, Connector);
@@ -191,8 +196,41 @@ MongoDB.prototype.fromDatabase = function(model, data) {
         // Convert the Binary into String
         data[p] = data[p].toString();
       }
+    } else if (data[p] && prop && prop.type && prop.type.name === 'GeoPoint' &&
+        this.settings.enableGeoIndexing === true) {
+      data[p] = {
+        lat: data[p].coordinates[1],
+        lng: data[p].coordinates[0],
+      };
     }
   }
+
+  return data;
+};
+
+/*!
+ * Convert JSON to database-appropriate format
+ *
+ * @param {String} model The model name
+ * @param {Object} data The JSON data to convert
+ */
+MongoDB.prototype.toDatabase = function(model, data) {
+  if (this.settings.enableGeoIndexing !== true) {
+    return data;
+  }
+
+  var props = this._models[model].properties;
+
+  for (var p in props) {
+    var prop = props[p];
+    if (data[p] && prop && prop.type && prop.type.name === 'GeoPoint') {
+      data[p] = {
+        coordinates: [data[p].lng, data[p].lat],
+        type: 'Point',
+      };
+    }
+  }
+
   return data;
 };
 
@@ -275,6 +313,9 @@ MongoDB.prototype.create = function(model, data, options, callback) {
     data._id = oid; // Set it to _id
     idName !== '_id' && delete data[idName];
   }
+
+  data = self.toDatabase(model, data);
+
   this.execute(model, 'insert', data, { safe: true }, function(err, result) {
     if (self.debug) {
       debug('create.callback', model, err, result);
@@ -312,6 +353,8 @@ MongoDB.prototype.save = function(model, data, options, callback) {
   var oid = self.coerceId(model, idValue);
   data._id = oid;
   idName !== '_id' && delete data[idName];
+
+  data = self.toDatabase(model, data);
 
   this.execute(model, 'save', data, { w: 1 }, function(err, result) {
     if (!err) {
@@ -459,6 +502,8 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
   var idName = self.idName(model);
   var oid = self.coerceId(model, id);
   delete data[idName];
+
+  data = self.toDatabase(model, data);
 
   // Check for other operators and sanitize the data obj
   data = self.parseUpdateData(model, data, options);
@@ -676,6 +721,39 @@ MongoDB.prototype.buildSort = function(model, order) {
   return sort;
 };
 
+function buildNearFilter(query, near) {
+  var coordinates = {};
+  if (typeof near.near === 'string') {
+    var s = near.near.split(',');
+
+    coordinates.lng = Number(s[0]);
+    coordinates.lat = Number(s[1]);
+  } else {
+    coordinates = near.near;
+  }
+
+  query.where[near.key] = {
+    near: {
+      $geometry: {
+        coordinates: [coordinates.lng, coordinates.lat],
+        type: 'Point',
+      },
+    },
+  };
+};
+
+function hasNearFilter(where) {
+  if (!where) return false;
+
+  for (var k in where) {
+    if (where[k] && typeof where[k] === 'object' && where[k].near) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 /**
  * Find matching model instances by the filter
  *
@@ -715,35 +793,39 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
       return callback(err);
     }
     var order = {};
-    if (!filter.order) {
-      var idNames = self.idNames(model);
-      if (idNames && idNames.length) {
-        filter.order = idNames;
-      }
-    }
-    if (filter.order) {
-      var keys = filter.order;
-      if (typeof keys === 'string') {
-        keys = keys.split(',');
-      }
-      for (var index = 0, len = keys.length; index < len; index++) {
-        var m = keys[index].match(/\s+(A|DE)SC$/);
-        var key = keys[index];
-        key = key.replace(/\s+(A|DE)SC$/, '').trim();
-        if (key === idName) {
-          key = '_id';
-        }
-        if (m && m[1] === 'DE') {
-          order[key] = -1;
-        } else {
-          order[key] = 1;
+
+    // don't apply sorting if dealing with a geo query
+    if (!hasNearFilter(filter.where)) {
+      if (!filter.order) {
+        var idNames = self.idNames(model);
+        if (idNames && idNames.length) {
+          filter.order = idNames;
         }
       }
-    } else {
-      // order by _id by default
-      order = { _id: 1 };
+      if (filter.order) {
+        var keys = filter.order;
+        if (typeof keys === 'string') {
+          keys = keys.split(',');
+        }
+        for (var index = 0, len = keys.length; index < len; index++) {
+          var m = keys[index].match(/\s+(A|DE)SC$/);
+          var key = keys[index];
+          key = key.replace(/\s+(A|DE)SC$/, '').trim();
+          if (key === idName) {
+            key = '_id';
+          }
+          if (m && m[1] === 'DE') {
+            order[key] = -1;
+          } else {
+            order[key] = 1;
+          }
+        }
+      } else {
+        // order by _id by default
+        order = { _id: 1 };
+      }
+      cursor.sort(order);
     }
-    cursor.sort(order);
 
     if (filter.limit) {
       cursor.limit(filter.limit);
@@ -901,6 +983,9 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
   var oid = self.coerceId(model, id);
   var idName = this.idName(model);
 
+
+  data = self.toDatabase(model, data);
+
   this.execute(model, 'findAndModify', { _id: oid }, [
     ['_id', 'asc'],
   ], data, {}, function(err, result) {
@@ -935,6 +1020,8 @@ MongoDB.prototype.update =
 
     where = self.buildWhere(model, where);
     delete data[idName];
+
+    data = self.toDatabase(model, data);
 
     // Check for other operators and sanitize the data obj
     data = self.parseUpdateData(model, data, options);
@@ -1040,7 +1127,14 @@ MongoDB.prototype.autoupdate = function(models, cb) {
             if (options.background === undefined) {
               options.background = true;
             }
+          } else if (properties[p].type && properties[p].type.name === 'GeoPoint') {
+            var indexType = typeof properties[p].index === 'string' ?
+              properties[p].index : '2dsphere';
           // If properties[p].index isn't an object we hardcode the background option and check for properties[p].unique
+            options.name = 'index' + indexType + p;
+
+            index[p] = indexType;
+            indexList.push({ keys: index, options: options });
           } else {
             options = { background: true };
             if (properties[p].unique) {

--- a/lib/test-utils.js
+++ b/lib/test-utils.js
@@ -1,0 +1,20 @@
+exports.getDistanceBetweenPoints = function getDistanceBetweenPoints(point1, point2) {
+  var R = 6371; // Radius of the earth in km
+  var dLat = deg2rad(point2.lat - point1.lat);  // deg2rad below
+  var dLon = deg2rad(point2.lng - point1.lng);
+  var a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(deg2rad(point1.lat)) * Math.cos(deg2rad(point2.lat)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  var d = R * c; // Distance in km
+
+  return d;
+};
+
+function deg2rad(deg) {
+  return deg * (Math.PI / 180);
+}
+
+exports.deg2rad = deg2rad;


### PR DESCRIPTION
I wrote basic support for 2d geo queries. It converts GeoPoints to the GeoJSON format that MongoDb uses and applies 2dsphere indexes to geopoint fields when you set index: true on your model definition. See the tests for more details. 

There's a hitch with backwards compatibility though, since thus far geopoints have been saved as {lat: Number, lng: Number} objects, and applying a 2dsphere index on a field like that will fail. Not entirely sure how to deal with that. I suppose one could do a data migration in the autoupdate method?