### PR TITLE
Allows optional use of $set, $addToSet, $push, $pull, $pullAll and $pop

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -323,12 +323,38 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, callback
 
   var id = self.getIdValue(model, data);
   var idName = self.idName(model);
-
+  var parsedData = {};
   var oid = ObjectID(id);
   delete data[idName];
-  this.collection(model).findAndModify({_id: oid}, [
+
+  if (self.settings.allowExtendedOperators === true) {
+    var acceptedOperators = [
+      // Field operators
+      '$currentDate', '$inc', '$max', '$min', '$mul', '$rename', '$setOnInsert', '$set', '$unset',
+      // Array operators
+      '$addToSet', '$pop', '$pullAll', '$pull', '$pushAll', '$push',
+      // Bitwise operator
+      '$bit'
+    ];
+
+    // each accepted operator will take its place on parsedData if defined
+    acceptedOperators.forEach(function(operator) {
+      if(data[operator]) parsedData[operator] = data[operator];
+    });
+
+    // if parsedData is still empty, then we fallback to $set operator
+    if(Object.keys(parsedData).length === 0) {
+      parsedData.$set = data;
+    }
+  } else {
+    parsedData.$set = data;
+  }
+
+  this.collection(model).findAndModify({
+    _id: oid
+  }, [
     ['_id', 'asc']
-  ], {$set: data}, {upsert: true, new: true}, function (err, result) {
+  ], parsedData, {upsert: true, new: true}, function (err, result) {
     if (self.debug) {
       debug('updateOrCreate.callback', model, id, err, result);
     }
@@ -608,10 +634,35 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
   }
   var oid = ObjectID(id);
   var idName = this.idName(model);
+  var parsedData = {};
   delete data[idName];
+
+  if (self.settings.allowExtendedOperators === true) {
+    var acceptedOperators = [
+      // Field operators
+      '$currentDate', '$inc', '$max', '$min', '$mul', '$rename', '$setOnInsert', '$set', '$unset',
+      // Array operators
+      '$addToSet', '$pop', '$pullAll', '$pull', '$pushAll', '$push',
+      // Bitwise operator
+      '$bit'
+    ];
+      
+    // each accepted operator will take its place on parsedData if defined
+    acceptedOperators.forEach(function(operator) {
+      if(data[operator]) parsedData[operator] = data[operator];
+    });
+
+    // if parsedData is still empty, then we fallback to $set operator
+    if(Object.keys(parsedData).length === 0) {
+      parsedData.$set = data;
+    }
+  } else {
+    parsedData.$set = data;
+  }
+
   this.collection(model).findAndModify({_id: oid}, [
     ['_id', 'asc']
-  ], {$set: data}, {}, function (err, result) {
+  ], parsedData, {}, function (err, result) {
     if (self.debug) {
       debug('updateAttributes.callback', model, id, err, result);
     }
@@ -797,9 +848,9 @@ MongoDB.prototype.automigrate = function (models, cb) {
       if (self.debug) {
         debug('drop collection: ', model);
       }
-      self.db.dropCollection(model, function(err, collection) {
+      self.db.dropCollection(model, function (err, collection) {
         if(err) {
-          if(!(err.name === 'MongoError' && err.ok === 0
+          if(!(err.name === 'MongoError' && err.ok === 0 
             && err.errmsg === 'ns not found')) {
             // For errors other than 'ns not found' (collection doesn't exist)
             return modelCallback(err);
@@ -838,5 +889,4 @@ MongoDB.prototype.ping = function (cb) {
     self.connect(function() {});
   }
 };
-
 

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -42,6 +42,17 @@ describe('mongodb', function () {
       }
     });
 
+    Product = db.define('Product', {
+      name: { type: String, length: 255, index: true },
+      description:{ type: String},
+      price: { type: Number },
+      pricehistory: { type: Object }
+    }, {
+      mongodb: {
+        collection: 'ProductCollection' // Customize the collection name
+      }
+    });
+
     PostWithStringId = db.define('PostWithStringId', {
       id: {type: String, id: true},
       title: { type: String, length: 255, index: true },
@@ -433,6 +444,315 @@ describe('mongodb', function () {
     });
   });
 
+  it('updateAttributes: $addToSet should append item to an Array if it doesn\'t already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90}]}, function (err, product) {
+
+      var newattributes= {$set : {description:'goes well with butter'}, $addToSet : { pricehistory: { '2014-12-12':110 } } };
+        
+      product.updateAttributes(newattributes, function (err1, inst) {
+        should.not.exist(err1);
+
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+          updatedproduct.pricehistory[1]['2014-12-12'].should.be.equal(110);
+          done();
+        });
+      });
+    });
+  });
+
+  it('updateOrCreate: $addToSet should append item to an Array if it doesn\'t already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90}]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$addToSet = { pricehistory: { '2014-12-12':110 } };
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        updatedproduct.pricehistory[1]['2014-12-12'].should.be.equal(110);
+
+        done();
+          
+      });
+    });
+  });
+
+
+  it('updateOrCreate: $addToSet should not append item to an Array if it does already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{ '2014-10-10':80 }]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$addToSet = { pricehistory: { '2014-10-10':80 } };
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+
+        done();
+          
+      });
+    });
+  });  
+
+  it('updateAttributes: $addToSet should not append item to an Array if it does already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{ '2014-10-10':80 }]}, function (err, product) {
+
+      var newattributes= {$set : {description:'goes well with butter'}, $addToSet : { pricehistory: { '2014-12-12':110 } } };
+        
+      product.updateAttributes(newattributes, function (err1, inst) {
+        should.not.exist(err1);
+
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+          updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+          done();
+        });
+      });
+    });
+  });   
+
+
+  it('updateAttributes: $pop should remove first or last item from an Array', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{'2014-10-10':80},{'2014-09-09':70}]}, function (err, product) {
+
+      var newattributes= {$set : {description:'goes well with butter'}, $addToSet : { pricehistory: 1 } };
+        
+      product.updateAttributes(newattributes, function (err1, inst) {
+        should.not.exist(err1);
+
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+          updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+          done();
+        });
+      });
+    });
+  }); 
+
+  it('updateOrCreate: $pop should remove first or last item from an Array', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{'2014-10-10':80},{'2014-09-09':70}]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$pop = { pricehistory: 1 };
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+
+        updatedproduct.$pop = { pricehistory: -1 };
+        Product.updateOrCreate(product, function (err, p) {
+          should.not.exist(err);
+          should.not.exist(p._id); 
+          updatedproduct.pricehistory[0]['2014-10-10'].should.be.equal(80);
+          done();
+        });
+      });
+    });
+  }); 
+
+  it('updateAttributes: $pull should remove items from an Array if they match a criteria', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[70,80,90,100]}, function (err, product) {
+
+      var newattributes= {$set : {description:'goes well with butter'}, $pull: { pricehistory: {$gte:90 } } };
+        
+      product.updateAttributes(newattributes, function (err1, updatedproduct) {
+        should.not.exist(err1);
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err1);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0].should.be.equal(70);
+          updatedproduct.pricehistory[1].should.be.equal(80);
+
+          done();
+        });
+      });
+    });
+  });
+
+  it('updateOrCreate: $pull should remove items from an Array if they match a criteria', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[70,80,90,100]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$pull = { pricehistory: {$gte:90 }};
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0].should.be.equal(70);
+        updatedproduct.pricehistory[1].should.be.equal(80);
+
+        done();
+      });
+    });
+  }); 
+
+  it('updateAttributes: $pullAll should remove items from an Array if they match a value from a list', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[70,80,90,100]}, function (err, product) {
+
+      var newattributes= {$set : {description:'goes well with butter'}, $pullAll : { pricehistory: [80,100]} };
+        
+      product.updateAttributes(newattributes, function (err1, inst) {
+        should.not.exist(err1);
+
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0].should.be.equal(70);
+          updatedproduct.pricehistory[1].should.be.equal(90);
+          
+          done();
+        });
+
+      });
+    });
+  }); 
+
+  it('updateOrCreate: $pullAll should remove items from an Array if they match a value from a list', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[70,80,90,100]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$pullAll = { pricehistory: [80,100]};
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0].should.be.equal(70);
+        updatedproduct.pricehistory[1].should.be.equal(90);
+
+        done();
+      });
+    });
+  });  
+
+
+  it('updateAttributes: $push should append item to an Array even if it does already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{ '2014-10-10':80 }]}, function (err, product) {
+      
+      var newattributes= {$set : {description:'goes well with butter'}, $push : { pricehistory: { '2014-10-10':80 } } };
+        
+      product.updateAttributes(newattributes, function (err1, inst) {
+        should.not.exist(err1);
+
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id); 
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.description.should.be.equal('goes well with butter');
+          updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+          updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+          updatedproduct.pricehistory[2]['2014-10-10'].should.be.equal(80);
+
+          done();
+        });
+      });
+    });
+  });  
+
+  it('updateOrCreate: $push should append item to an Array even if it does already exist', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90},{ '2014-10-10':80 }]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$push = { pricehistory: { '2014-10-10':80 } };
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+        updatedproduct.pricehistory[2]['2014-10-10'].should.be.equal(80);
+
+        done();
+          
+      });
+    });
+  });
+
+  it('updateOrCreate: should handle combination of operators and top level properties without errors', function (done) {
+    Product.dataSource.settings.allowExtendedOperators = true;
+    Product.create({name: 'bread', price: 100, ingredients:['flour'],pricehistory:[{'2014-11-11':90},{ '2014-10-10':80 }]}, function (err, product) {
+
+      product.$set = {description:'goes well with butter'};
+      product.$push = { ingredients: 'water' };
+      product.$addToSet = { pricehistory: { '2014-09-09':70 } };
+      product.description = 'alternative description';
+        
+      Product.updateOrCreate(product, function (err, updatedproduct) {
+        should.not.exist(err);
+        should.not.exist(updatedproduct._id); 
+        updatedproduct.id.should.be.eql(product.id);
+        updatedproduct.name.should.be.equal(product.name);
+        updatedproduct.description.should.be.equal('goes well with butter');
+        updatedproduct.ingredients[0].should.be.equal('flour');
+        updatedproduct.ingredients[1].should.be.equal('water');
+        updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        updatedproduct.pricehistory[1]['2014-10-10'].should.be.equal(80);
+        updatedproduct.pricehistory[2]['2014-09-09'].should.be.equal(70);
+
+        done();
+          
+      });
+    });
+  });
+
+ 
   it('updateOrCreate should update the instance without removing existing properties', function (done) {
     Post.create({title: 'a', content: 'AAA', comments: ['Comment1']}, function (err, post) {
       post = post.toObject();


### PR DESCRIPTION
At this point, loopback's mongodb connector implementation of  updateOrCreate has the [$set](http://docs.mongodb.org/manual/reference/operator/update/set/) operator hardcoded. For example, given the Product 

```
{id:12345, name:'oldname','price':100, 'historicprice':[90]}
```
the following operation
```
Model.updateOrCreate({
     id:12345, 
     name:'newname'
}, function(err,cb));
```
would result in an updated model with all the original properties, but whose name is now 'newname'.

```
{id:12345, name:'newname','price':100, 'historicprice':[90]};
```

With this pull request, you can still use the current method (this is, passing updateOrCreate an object with the properties you want to update) but you can also refine the syntax to specify what do you want to update (under the $set key) and at the same time manipulate an array using [MongoDB array update operators](http://docs.mongodb.org/manual/reference/operator/update-array/). Currently, there's support for $addToSet, $push, $pull, $pullAll and $pop. 

**An example with [$addToSet](http://docs.mongodb.org/manual/reference/operator/update/addToSet/)** 

Given the aforementiones model, the following operation

```
Model.updateOrCreate({
     id:12345, 
     $set: {name:'newname'},
     $addToSet: {historicprice:95},
}, function(err,cb));
```

will $set  a new name, and will append a new value to 'historicprice' instead of overwriting the existing one.

```
{id:12345, name:'newname','price':100, 'historicprice':[90,95]};
```

This is part of an ongoing effort to implement more native MongoDB functions to properly replace existing apps that use lower level libraries.
