### PR TITLE
Support for regex flags in like/nlike operator

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -463,7 +463,9 @@ MongoDB.prototype.buildWhere = function (model, where) {
       return;
     }
     var spec = false;
+    var options = null;
     if (cond && cond.constructor.name === 'Object') {
+      options = cond.options;
       spec = Object.keys(cond)[0];
       cond = cond[spec];
     }
@@ -476,9 +478,9 @@ MongoDB.prototype.buildWhere = function (model, where) {
           return ObjectID(x);
         })};
       } else if (spec === 'like') {
-        query[k] = {$regex: new RegExp(cond)};
+        query[k] = {$regex: new RegExp(cond, options)};
       } else if (spec === 'nlike') {
-        query[k] = {$not: new RegExp(cond)};
+        query[k] = {$not: new RegExp(cond, options)};
       } else if (spec === 'neq') {
         query[k] = {$ne: cond};
       }

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1182,6 +1182,16 @@ describe('mongodb', function () {
     });
   });
 
+  it('should allow to find using case insensitive like', function (done) {
+    Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
+      Post.find({where: {title: {like: 'm.+st', options: 'i'}}}, function (err, posts) {
+        should.not.exist(err);
+        posts.should.have.property('length', 1);
+        done();
+      });
+    });
+  });
+
   it('should support like for no match', function (done) {
     Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
       Post.find({where: {title: {like: 'M.+XY'}}}, function (err, posts) {
@@ -1195,6 +1205,16 @@ describe('mongodb', function () {
   it('should allow to find using nlike', function (done) {
     Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
       Post.find({where: {title: {nlike: 'M.+st'}}}, function (err, posts) {
+        should.not.exist(err);
+        posts.should.have.property('length', 0);
+        done();
+      });
+    });
+  });
+
+  it('should allow to find using case insensitive nlike', function (done) {
+    Post.create({title: 'My Post', content: 'Hello'}, function (err, post) {
+      Post.find({where: {title: {nlike: 'm.+st', options: 'i'}}}, function (err, posts) {
         should.not.exist(err);
         posts.should.have.property('length', 0);
         done();


### PR DESCRIPTION
Per @andrewburgess:  Basically just added the ability to specify Regex flags so that case insensitive search can be done.

Format would be:

```
Post.find({
  where: {
    title: {
      like: 'someth.*',
      options: 'i'
    }
  }
});
```

Will also allow filters to be used in queries like so:

```
?filter={"where":{"title":{"like":"someth.*","options":"i"}}}
```