### PR TITLE
Fix unit-tests on iojs 1.0

### DIFF
--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -109,7 +109,7 @@ describe('mongodb', function () {
       });
       ds.ping(function(err) {
         (!!err).should.be.true;
-        err.message.should.be.equal('connect ECONNREFUSED');
+        err.message.should.match(/connect ECONNREFUSED/);
         done();
       });
     });


### PR DESCRIPTION
iojs includes the host:port string in the error mesage. This commit
changes the check to a regular expression that accepts both old (v0.10)
and new (v1.0) error messages.

/cc @raymondfeng FYI, you have already approved this commit in #85 