### PR TITLE
implement optmized findOrCreate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 coverage
+.idea

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -938,11 +938,11 @@ MongoDB.prototype.ping = function (cb) {
  * Find a matching model instances by the filter or create a new instance
  *
  * @param {String} model The model name
- * @param {Object} data The model instance data
  * @param {Object} filter The filter
+ * @param {Object} data The model instance data
  * @param {Function} [callback] The callback function
  */
-MongoDB.prototype.findOrCreate = function (model, filter, data, callback) {
+MongoDB.prototype.findOrCreate = function (model, filter, data, options, callback) {
   var self = this;
   if (self.debug) {
     debug('findOrCreate', model, filter, data);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -524,7 +524,40 @@ MongoDB.prototype.buildWhere = function (model, where) {
     }
   });
   return query;
-}
+};
+
+MongoDB.prototype.buildSort = function (model, order) {
+  var sort = {}, idName = this.idName(model);
+  if (!order) {
+    var idNames = this.idNames(model);
+    if (idNames && idNames.length) {
+      order = idNames;
+    }
+  }
+  if (order) {
+    var keys = order;
+    if (typeof keys === 'string') {
+      keys = keys.split(',');
+    }
+    for (var index = 0, len = keys.length; index < len; index++) {
+      var m = keys[index].match(/\s+(A|DE)SC$/);
+      var key = keys[index];
+      key = key.replace(/\s+(A|DE)SC$/, '').trim();
+      if (key === idName) {
+        key = '_id';
+      }
+      if (m && m[1] === 'DE') {
+        sort[key] = -1;
+      } else {
+        sort[key] = 1;
+      }
+    }
+  } else {
+    // order by _id by default
+    sort = {_id: 1};
+  }
+  return sort;
+};
 
 /**
  * Find matching model instances by the filter
@@ -558,36 +591,8 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
     cursor = this.collection(model).find(query);
   }
 
-  var order = {};
-  if (!filter.order) {
-    var idNames = this.idNames(model);
-    if (idNames && idNames.length) {
-      filter.order = idNames;
-    }
-  }
-  if (filter.order) {
-    var keys = filter.order;
-    if (typeof keys === 'string') {
-      keys = keys.split(',');
-    }
-    for (var index = 0, len = keys.length; index < len; index++) {
-      var m = keys[index].match(/\s+(A|DE)SC$/);
-      var key = keys[index];
-      key = key.replace(/\s+(A|DE)SC$/, '').trim();
-      if(key === idName) {
-        key = '_id';
-      }
-      if (m && m[1] === 'DE') {
-        order[key] = -1;
-      } else {
-        order[key] = 1;
-      }
-    }
-  } else {
-    // order by _id by default
-    order = {_id: 1};
-  }
-  cursor.sort(order);
+  var sort = self.buildSort(model, filter.order);
+  cursor.sort(sort);
 
   if (filter.limit) {
     cursor.limit(filter.limit);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -934,3 +934,76 @@ MongoDB.prototype.ping = function (cb) {
   }
 };
 
+/**
+ * Find a matching model instances by the filter or create a new instance
+ *
+ * @param {String} model The model name
+ * @param {Object} data The model instance data
+ * @param {Object} filter The filter
+ * @param {Function} [callback] The callback function
+ */
+MongoDB.prototype.findOrCreate = function (model, filter, data, callback) {
+  var self = this;
+  if (self.debug) {
+    debug('findOrCreate', model, filter, data);
+  }
+
+  var idValue = self.getIdValue(model, data);
+  var idName = self.idName(model);
+
+  if (idValue == null) {
+    delete data[idName]; // Allow MongoDB to generate the id
+  } else {
+    var oid = ObjectID(idValue); // Is it an Object ID?
+    data._id = oid; // Set it to _id
+    idName !== '_id' && delete data[idName];
+  }
+
+  filter = filter || {};
+  var query = {};
+  if (filter.where) {
+    if (filter.where[idName]) {
+      var id = filter.where[idName];
+      delete filter.where[idName];
+      id = ObjectID(id);
+      filter.where._id = id;
+    }
+    query = self.buildWhere(model, filter.where);
+  }
+
+  var sort = self.buildSort(model, filter.order);
+
+  this.collection(model).findOneAndUpdate(
+    query,
+    { $setOnInsert: data },
+    { projection: filter.fields, sort: sort, upsert: true },
+    function (err, result) {
+      if (self.debug) {
+        debug('findOrCreate.callback', model, filter, err, result);
+      }
+      if (err) {
+        return callback(err);
+      }
+
+      var value = result.value;
+      var created = !!result.lastErrorObject.upserted;
+
+      if (created && (value == null || Object.keys(value).length == 0)) {
+        value = data;
+        self.setIdValue(model, value, result.lastErrorObject.upserted);
+      } else {
+        value = self.fromDatabase(model, value);
+        self.setIdValue(model, value, value._id);
+      }
+
+      value && idName !== '_id' && delete value._id;
+
+      if (filter && filter.include) {
+        self._models[model].model.include([value], filter.include, function (err, data) {
+          callback(err, data[0], created);
+        });
+      } else {
+        callback(null, value, created);
+      }
+    });
+};


### PR DESCRIPTION
1. require strongloop/loopback-datasource-juggler#419 to be merged first
2. cause [one test fail](https://github.com/strongloop/loopback-datasource-juggler/blob/master/test/relations.test.js#L1465) due to id generation, see below

The test fail because the order of pictures are different. The *Example* picture is linked to the author, which calls `findOrCreate()`, but other two don't.

1. By default, *mongodb-driver* will take care of `_id` (generate in client process), but `findAndModify` command is different, when it results an upsert, the `_id` is generated by mongodb server(generate in server process).
2. the connector sorts query by `_id` field, the result might be different among environments.

Any thoughts?