### PR TITLE
nin filter map to mongo ObjectId

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -425,6 +425,11 @@ MongoDB.prototype.buildWhere = function (model, where) {
           if ('string' !== typeof x) return x;
           return ObjectID(x);
         })};
+      } else if (spec === 'nin') {
+        query[k] = { $nin: cond.map(function (x) {
+          if ('string' !== typeof x) return x;
+          return ObjectID(x);
+        })};
       } else if (spec === 'like') {
         query[k] = {$regex: new RegExp(cond)};
       } else if (spec === 'nlike') {


### PR DESCRIPTION
The inq filter maps the data to mongo ObjectId()
This change is to implement the same behaviour to nin filter.

related issue :
https://github.com/strongloop/loopback-connector-mongodb/issues/52
