### PR TITLE
Let like: be case insensitive with (?i)

### DIFF
--- a/example/model.js
+++ b/example/model.js
@@ -37,6 +37,10 @@ Customer.destroyAll(function (err) {
       Customer.find({where: {'emails.0.label': 'work'}}, function(err, customers) {
         console.log('Customers matched by emails.0.label', customers);
       });
+
+      Customer.find({where: {'name': {like: '(?i)john'}}, function(err, customers) {
+        console.log('Customers matched case insensitively by name', customers);
+      });
       /*
        customer1.updateAttributes({name: 'John'}, function(err, result) {
        console.log(err, result);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -439,6 +439,19 @@ function idIncluded(fields, idName) {
   return true;
 }
 
+// make { like: "(?i)whatever" } a case insensitive version of { like: "whatever" }
+function newRegExp(cond) {
+  if (typeof cond === 'string') {
+    if (cond.indexOf('(?i)') !== 0) {
+      return new RegExp(cond);
+    } else {
+      return new RegExp(cond.substring(4), 'i');
+    }
+  } else {
+    return new RegExp(cond);
+  }
+}
+
 MongoDB.prototype.buildWhere = function (model, where) {
   var self = this;
   var query = {};
@@ -478,9 +491,9 @@ MongoDB.prototype.buildWhere = function (model, where) {
           return ObjectID(x);
         })};
       } else if (spec === 'like') {
-        query[k] = {$regex: new RegExp(cond, options)};
+        query[k] = {$regex: newRegExp(cond, options)};
       } else if (spec === 'nlike') {
-        query[k] = {$not: new RegExp(cond, options)};
+        query[k] = {$not: newRegExp(cond, options)};
       } else if (spec === 'neq') {
         query[k] = {$ne: cond};
       }


### PR DESCRIPTION
Make { like: "(?i)whatever" } a case insensitive version of { like: "whatever" }.

Fix for https://github.com/strongloop/loopback-connector-mongodb/issues/108