### PR TITLE
Minor fixes

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -655,6 +655,8 @@ MongoDB.prototype.count = function count(model, callback, where) {
 MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
   var self = this;
 
+  if (Object.keys(data).length === 0) return cb && cb();
+
   // Check for other operators and sanitize the data obj
   data = self.parseUpdateData(model, data);
 
@@ -673,7 +675,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, cb) {
     var object = result && result.value;
     if (!err && !object) {
       // No result
-      err = 'No ' + model + ' found for id ' + id;
+      err = new Error('No ' + model + ' found for id ' + id);
     }
     self.setIdValue(model, object, id);
     object && idName !== '_id' && delete object._id;

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -678,6 +678,29 @@ describe('mongodb connector', function () {
     });
   });
 
+  it('updateAttributes: handle empty data', function (done) {
+    Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90}]}, function (err, product) {
+      product.updateAttributes({}, function (err1, inst) {
+        should.not.exist(err1);
+        should.not.exist(inst._id);
+        inst.id.should.be.eql(product.id);
+        inst.name.should.be.equal(product.name);
+        inst.pricehistory.should.have.length(1);
+        inst.pricehistory[0]['2014-11-11'].should.be.equal(90);
+        
+        Product.findById(product.id, function (err2, updatedproduct) {
+          should.not.exist(err2);
+          should.not.exist(updatedproduct._id);
+          updatedproduct.id.should.be.eql(product.id);
+          updatedproduct.name.should.be.equal(product.name);
+          updatedproduct.pricehistory.should.have.length(1);
+          updatedproduct.pricehistory[0]['2014-11-11'].should.be.equal(90);
+          done();
+        });
+      });
+    });
+  });
+
   it('updateAttributes: $addToSet should append item to an Array if it doesn\'t already exist', function (done) {
     Product.dataSource.settings.allowExtendedOperators = true;
     Product.create({name: 'bread', price: 100, pricehistory:[{'2014-11-11':90}]}, function (err, product) {


### PR DESCRIPTION
Allow `data` to be empty - otherwise MongoDB (2.6+) will throw; handle 'noop' updateAttributes gracefully.

Example use-case: 

```
Model.observe('before save', function(ctx, next) {
  if (ctx.data) ctx.data = _.omit(ctx.data, 'reserved', 'property', 'example');
  // ctx.data might end up empty now - and Mongo will blow up
  next();
});
```

Fix: return proper error object, not string.

/cc @raymondfeng @bajtos 