### PR TITLE
Default to `undefined` instead of `0`

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -619,7 +619,9 @@ MongoDB.prototype.destroyAll = function destroyAll(model, where, callback) {
     if (self.debug)
       debug('destroyAll.callback', model, where, err, results);
 
-    var affectedCount = (results.result && results.result.n) || 0;
+    var affectedCount = results.result && typeof results.result.n === 'number' ?
+        results.result.n : undefined;
+
     callback && callback(err, {count: affectedCount});
   });
 };
@@ -707,7 +709,9 @@ MongoDB.prototype.update =
         if (self.debug)
           debug('updateAll.callback', model, where, data, err, results);
 
-        var affectedCount = (results.result && results.result.n) || 0;
+        var affectedCount = results.result && typeof results.result.n ===
+            'number' ? results.result.n : undefined;
+
         cb && cb(err, {count: affectedCount});
       });
   };


### PR DESCRIPTION
On `updateAll` or `destroyAll`, default to `undefined` instead of `0`.

Connect to strongloop/loopback#1167