### PR TITLE
Replaced ensureIndex() with createIndex()

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -851,7 +851,7 @@ MongoDB.prototype.disconnect = function (cb) {
 };
 
 /**
- * Perform autoupdate for the given models. It basically calls ensureIndex
+ * Perform autoupdate for the given models. It basically calls createIndex
  * @param {String[]} [models] A model name or an array of model names. If not
  * present, apply to all models
  * @param {Function} [cb] The callback function
@@ -941,9 +941,9 @@ MongoDB.prototype.autoupdate = function (models, cb) {
 
       async.each(indexList, function (index, indexCallback) {
         if (self.debug) {
-          debug('ensureIndex: ', index);
+          debug('createIndex: ', index);
         }
-        self.collection(model).ensureIndex(index.fields || index.keys, index.options, indexCallback);
+        self.collection(model).createIndex(index.fields || index.keys, index.options, indexCallback);
       }, modelCallback);
 
     }, cb);
@@ -956,7 +956,7 @@ MongoDB.prototype.autoupdate = function (models, cb) {
 
 /**
  * Perform automigrate for the given models. It drops the corresponding collections
- * and calls ensureIndex
+ * and calls createIndex
  * @param {String[]} [models] A model name or an array of model names. If not present, apply to all models
  * @param {Function} [cb] The callback function
  */


### PR DESCRIPTION
as `ensureIndex()` is now deprecated.

Reference: http://docs.mongodb.org/manual/reference/method/db.collection.ensureIndex/