### PR TITLE
Race condition listening to fullsetup event from an db object in a callback

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -149,8 +149,7 @@ function connectToMongoDB(url, options, callback) {
       if (err) return callback(err);
 
       if (db) {
-        db.on('fullsetup', function() {
-          db.authenticate(user, password, options, function(err, ok) {
+        db.authenticate(user, password, options, function(err, ok) {
             if (err) return callback(err);
             if (ok) {
               return callback(null, db);
@@ -158,7 +157,6 @@ function connectToMongoDB(url, options, callback) {
               return callback(null, null);
             }
           });
-        });
         return;
       }
       callback(err, db);


### PR DESCRIPTION
There is a race condition listening to the db.on('fullsetup') event from the mongodb db module. 

Because the mongodb module does not fire events on process.nextTick() then the callback may get fired after the event has already run which yields a race condition where db.authenticate never gets fired.

This will cause situation where the juggler will see a timeout in connecting to the database simply because the callback never gets called.