### PR TITLE
Issue #154: Fix relational RoleMapping

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -23,7 +23,7 @@ function ObjectID(id) {
     // MongoDB's ObjectID constructor accepts number, 12-byte string or 24-byte
     // hex string. For LoopBack, we only allow 24-byte hex string, but 12-byte
     // string such as 'line-by-line' should be kept as string
-    if(/^[0-9a-fA-F]{24}$/.test(id)) {
+    if(/^[0-9a-fA-F]{24}$/.test(id) || /^[0-9a-fA-F]{12}$/.test(id)) {
       return new mongodb.ObjectID(id);
     } else {
       return id;


### PR DESCRIPTION
when the RoleMapping and Role datasource where linked on mongodb the relational mechanism did not work.
With this fix, the relational is right.
The problem was than the principalId was recorded as a string and not as an ObjectId in the mongo collection RoleMapping.