### PR TITLE
Added a setting to enable optimsied findOrCreate method 

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -87,6 +87,9 @@ function MongoDB(settings, dataSource) {
   }
 
   this.dataSource = dataSource;
+  if (this.settings.enableOptimisedfindOrCreate === true) {
+      MongoDB.prototype.findOrCreate = OptimisedfindOrCreate;
+  }
 
 }
 
@@ -937,12 +940,14 @@ MongoDB.prototype.ping = function (cb) {
 /**
  * Find a matching model instances by the filter or create a new instance
  *
+ * Only supported on mongodb 2.6+
+ *
  * @param {String} model The model name
  * @param {Object} data The model instance data
  * @param {Object} filter The filter
  * @param {Function} [callback] The callback function
  */
-MongoDB.prototype.findOrCreate = function (model, filter, data, callback) {
+function OptimisedfindOrCreate(model, filter, data, callback) {
   var self = this;
   if (self.debug) {
     debug('findOrCreate', model, filter, data);

--- a/test/persistence-hooks.test.js
+++ b/test/persistence-hooks.test.js
@@ -1,4 +1,19 @@
 var should = require('./init');
 var suite = require('loopback-datasource-juggler/test/persistence-hooks.suite.js');
 
-suite(global.getDataSource(), should);
+var customConfig = {
+    "test": {
+        "mongodb": {
+            "enableOptimisedfindOrCreate": false,
+        }
+    }
+};
+
+if (process.env.MONGODB_VERSION &&
+        require('semver').satisfies('2.6.0', '>' +
+        process.env.MONGODB_VERSION)) {
+            customConfig.test.mongodb.enableOptimisedfindOrCreate = true;
+        }
+
+
+suite(global.getDataSource(customConfig), should);


### PR DESCRIPTION
so that connector continues to work with mongodb < 2.6. Not sure if this is acceptable but wanted to get some feedback.