### PR TITLE
Enable Model.settings.mongodb.allowExtendedOperators

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -383,13 +383,16 @@ MongoDB.prototype.find = function find(model, id, options, callback) {
  * @param data
  * @returns {*}
  */
-MongoDB.prototype.parseUpdateData = function(model, data) {
+MongoDB.prototype.parseUpdateData = function(model, data, options) {
+  options = options || {};
   var parsedData = {};
   
   var modelClass = this._models[model];
   
   var allowExtendedOperators = this.settings.allowExtendedOperators;
-  if (allowExtendedOperators !== false && modelClass.settings.mongodb
+  if (options.hasOwnProperty('allowExtendedOperators')) {
+      allowExtendedOperators = options.allowExtendedOperators === true;
+  } else if (allowExtendedOperators !== false && modelClass.settings.mongodb
       && modelClass.settings.mongodb.hasOwnProperty('allowExtendedOperators')) {
       allowExtendedOperators = modelClass.settings.mongodb.allowExtendedOperators === true;
   } else if (allowExtendedOperators === true) {
@@ -447,7 +450,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
   delete data[idName];
 
   // Check for other operators and sanitize the data obj
-  data = self.parseUpdateData(model, data);
+  data = self.parseUpdateData(model, data, options);
 
   this.execute(model, 'findAndModify', {
     _id: oid
@@ -748,7 +751,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
   var self = this;
 
   // Check for other operators and sanitize the data obj
-  data = self.parseUpdateData(model, data);
+  data = self.parseUpdateData(model, data, options);
 
   if (self.debug) {
     debug('updateAttributes', model, id, data);
@@ -792,7 +795,7 @@ MongoDB.prototype.update =
     delete data[idName];
 
     // Check for other operators and sanitize the data obj
-    data = self.parseUpdateData(model, data);
+    data = self.parseUpdateData(model, data, options);
 
     this.execute(model, 'update', where, data, {multi: true, upsert: false},
       function(err, info) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -385,8 +385,18 @@ MongoDB.prototype.find = function find(model, id, options, callback) {
  */
 MongoDB.prototype.parseUpdateData = function(model, data) {
   var parsedData = {};
-
-  if (this.settings.allowExtendedOperators === true) {
+  
+  var modelClass = this._models[model];
+  
+  var allowExtendedOperators = this.settings.allowExtendedOperators;
+  if (allowExtendedOperators !== false && modelClass.settings.mongodb
+      && modelClass.settings.mongodb.hasOwnProperty('allowExtendedOperators')) {
+      allowExtendedOperators = modelClass.settings.mongodb.allowExtendedOperators === true;
+  } else if (allowExtendedOperators === true) {
+      allowExtendedOperators = true;
+  }
+  
+  if (allowExtendedOperators) {
     // Check for other operators and sanitize the data obj
     var acceptedOperators = [
       // Field operators

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -610,6 +610,42 @@ describe('mongodb connector', function () {
           });
         });
       });
+      
+      it('should be possible to enable using options - even if globally disabled', function(done) {
+        User.dataSource.settings.allowExtendedOperators = false;
+        var options = { allowExtendedOperators: true };
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+          
+          User.updateAll({name: 'Al'}, {'$rename': {name: 'firstname'}}, options, function(err, updatedusers) {
+            should.not.exist(err);
+            updatedusers.should.have.property('count', 1);
+
+            User.find({where: {firstname: 'Al'}}, function(err, foundusers) {
+              should.not.exist(err);
+              foundusers.length.should.be.equal(1);
+
+              done();
+            });
+
+          });
+        });
+      });
+      
+      it('should be possible to disable using options - even if globally disabled', function(done) {
+        User.dataSource.settings.allowExtendedOperators = true;
+        var options = { allowExtendedOperators: false };
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+
+          User.updateAll({name: 'Al'}, {'$rename': {name: 'firstname'}}, options, function(err, updatedusers) {
+            should.exist(err);
+            err.name.should.equal('MongoError');
+            err.errmsg.should.equal('The dollar ($) prefixed field \'$rename\' in \'$rename\' is not valid for storage.');
+            done();
+          });
+        });
+      });
 
       it('should be possible to use the $inc operator', function(done) {
         User.dataSource.settings.allowExtendedOperators = true;

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -82,6 +82,7 @@ describe('mongodb connector', function () {
   });
 
   beforeEach(function (done) {
+    User.settings.mongodb = {};
     User.destroyAll(function () {
       Post.destroyAll(function () {
         PostWithObjectId.destroyAll(function () {
@@ -555,6 +556,57 @@ describe('mongodb connector', function () {
               });
 
             });
+          });
+        });
+      });
+      
+      it('should be possible to enable per model settings', function(done) {
+        User.dataSource.settings.allowExtendedOperators = null;
+        User.settings.mongodb = { allowExtendedOperators: true };
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+
+          User.updateAll({name: 'Al'}, {'$rename': {name: 'firstname'}}, function(err, updatedusers) {
+            should.not.exist(err);
+            updatedusers.should.have.property('count', 1);
+
+            User.find({where: {firstname: 'Al'}}, function(err, foundusers) {
+              should.not.exist(err);
+              foundusers.length.should.be.equal(1);
+
+              done();
+            });
+
+          });
+        });
+      });
+
+      it('should not be possible to enable per model settings when globally disabled', function(done) {
+        User.dataSource.settings.allowExtendedOperators = false;
+        User.settings.mongodb = { allowExtendedOperators: true };
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+
+          User.updateAll({name: 'Al'}, {'$rename': {name: 'firstname'}}, function(err, updatedusers) {
+            should.exist(err);
+            err.name.should.equal('MongoError');
+            err.errmsg.should.equal('The dollar ($) prefixed field \'$rename\' in \'$rename\' is not valid for storage.');
+            done();
+          });
+        });
+      });
+
+      it('should not be possible to use when disabled per model settings', function(done) {
+        User.dataSource.settings.allowExtendedOperators = true;
+        User.settings.mongodb = { allowExtendedOperators: false };
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+
+          User.updateAll({name: 'Al'}, {'$rename': {name: 'firstname'}}, function(err, updatedusers) {
+            should.exist(err);
+            err.name.should.equal('MongoError');
+            err.errmsg.should.equal('The dollar ($) prefixed field \'$rename\' in \'$rename\' is not valid for storage.');
+            done();
           });
         });
       });


### PR DESCRIPTION
Implements #163 as follows:

- when enabled on the connector (`=== true`), all models will allow extended operators
- when disabled on the connector (`=== false`), models will not allow extended operators at all, ever
- when enabled on the connector, disabling the model setting (`=== false`) will prevent extended operators for that single model
- when enabled on the connector, enabling the model setting has no effect (it remains enabled)
- when not explicitly set on the connector, use the model's setting appropriately (`true / false`)

/cc @raymondfeng 