### PR TITLE
Add the option to bypass the default sort order by using option.useDefaultSort: false

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -682,17 +682,20 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
   }
 
   function processResponse(err, cursor) {
+    var useDefaultSort = options.useDefaultSort !== false;
+
     if (err) {
       return callback(err);
     }
-    var order = {};
-    if (!filter.order) {
+    var order = null;
+    if (!filter.order && useDefaultSort) {
       var idNames = self.idNames(model);
       if (idNames && idNames.length) {
         filter.order = idNames;
       }
     }
     if (filter.order) {
+      order = {};
       var keys = filter.order;
       if (typeof keys === 'string') {
         keys = keys.split(',');
@@ -710,11 +713,14 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
           order[key] = 1;
         }
       }
-    } else {
+    } else if (useDefaultSort) {
       // order by _id by default
       order = {_id: 1};
     }
-    cursor.sort(order);
+
+    if (order) {
+      cursor.sort(order);
+    }
 
     if (filter.limit) {
       cursor.limit(filter.limit);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1286,6 +1286,35 @@ describe('mongodb connector', function () {
       });
     });
 
+  it('find should not order by id if the order is not set for the query filter and option useDefaultSort is false',
+    function (done) {
+      var options = {useDefaultSort: false};
+
+      PostWithStringId.create({id: '2', title: 'c', content: 'CCC'}, function (err, post) {
+        PostWithStringId.create({id: '1', title: 'd', content: 'DDD'}, function (err, post) {
+
+          PostWithStringId.find({}, options, function (err, posts) {
+            should.not.exist(err);
+            posts.length.should.be.equal(2);
+            posts[0].id.should.be.equal('2');
+
+            PostWithStringId.find({limit: 1, offset: 0}, options, function (err, posts) {
+              should.not.exist(err);
+              posts.length.should.be.equal(1);
+              posts[0].id.should.be.equal('2');
+
+              PostWithStringId.find({limit: 1, offset: 1}, options, function (err, posts) {
+                should.not.exist(err);
+                posts.length.should.be.equal(1);
+                posts[0].id.should.be.equal('1');
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
   it('should report error on duplicate keys', function (done) {
     Post.create({title: 'd', content: 'DDD'}, function (err, post) {
       Post.create({id: post.id, title: 'd', content: 'DDD'}, function (err, post) {


### PR DESCRIPTION
This is useful when using operators that provide their own sort. For instance `nearSphere` returns the results from lowest to greatest distance.

Addresses the following issues #147, #55 

```
Model.find({}, {useDefaultSort:false});
```

The bypass will only trigger if there is no `order` in the filter and the value is explicitely set to `false`
