### PR TITLE
Added support for renaming columns

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -188,6 +188,9 @@ MongoDB.prototype.fromDatabase = function (model, data) {
       }
     }
   }
+
+  // Override custom column names
+  data = this.fromDatabaseToPropertyNames(model, data);
   return data;
 };
 
@@ -265,6 +268,10 @@ MongoDB.prototype.create = function (model, data, options, callback) {
     data._id = oid; // Set it to _id
     idName !== '_id' && delete data[idName];
   }
+
+  // Convert custom column names
+  data = self.fromPropertyToDatabaseNames(model, data);
+
   this.execute(model, 'insert', data, {safe: true}, function (err, result) {
     if (self.debug) {
       debug('create.callback', model, err, result);
@@ -302,6 +309,9 @@ MongoDB.prototype.save = function (model, data, options, callback) {
   var oid = self.coerceId(model, idValue);
   data._id = oid;
   idName !== '_id' && delete data[idName];
+
+  // Convert custom column names
+  data = self.fromPropertyToDatabaseNames(model, data);
 
   this.execute(model, 'save', data, {w: 1}, function (err, result) {
     if (!err) {
@@ -453,6 +463,9 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
   // Check for other operators and sanitize the data obj
   data = self.parseUpdateData(model, data, options);
 
+  // Convert custom column names
+  data = self.fromPropertyToDatabaseNames(model, data);
+
   this.execute(model, 'findAndModify', {
     _id: oid
   }, [
@@ -561,6 +574,9 @@ MongoDB.prototype.buildWhere = function (model, where) {
     }
     var prop = self.getPropertyDefinition(model, propName);
 
+    // Convert property to database column name
+    k = self.getDatabaseColumnName(model, k);
+
     var spec = false;
     var options = null;
     if (cond && cond.constructor.name === 'Object') {
@@ -633,7 +649,10 @@ MongoDB.prototype.buildSort = function (model, order) {
       key = key.replace(/\s+(A|DE)SC$/, '').trim();
       if (key === idName) {
         key = '_id';
+      } else {
+        key = this.getDatabaseColumnName(model, key);
       }
+
       if (m && m[1] === 'DE') {
         sort[key] = -1;
       } else {
@@ -646,6 +665,83 @@ MongoDB.prototype.buildSort = function (model, order) {
   }
   return sort;
 };
+
+MongoDB.prototype.getDatabaseColumnName = function(model, propName) {
+  if (typeof model === 'string') {
+    model = this._models[model];
+  }
+
+  if (typeof model !== 'object') {
+    return propName; // unknown model type?
+  }
+
+  if (typeof model.properties !== 'object') {
+    return propName; // missing model properties?
+  }
+
+  var prop = model.properties[propName] || {};
+  
+  // console.log('getDatabaseColumnName', propName, prop);
+
+  // Try mongo overrides
+  if (prop.mongodb) {
+    propName = prop.mongodb.columnName || prop.mongodb.column || propName;
+  }
+
+  // Try top level overrides
+  propName = prop.columnName || prop.column || propName;
+
+  // Done
+  // console.log('->', propName);
+  return propName;
+}
+
+MongoDB.prototype.convertColumnNames = function(model, data, direction) {
+  if (typeof data !== 'object') {
+    return data; // skip
+  }
+
+  if (typeof model === 'string') {
+    model = this._models[model];
+  }
+
+  if (typeof model !== 'object') {
+    return data; // unknown model type?
+  }
+
+  if (typeof model.properties !== 'object') {
+    return data; // missing model properties?
+  }
+
+  for(var propName in model.properties) {
+    var columnName = this.getDatabaseColumnName(model, propName);
+
+    // Copy keys/data if needed
+    if (!propName || !columnName || propName === columnName) {
+      continue;
+    }
+
+    if (direction === 'database') {
+      data[columnName] = data[propName];
+      delete data[propName];
+    }
+
+    if (direction === 'property') {
+      data[propName] = data[columnName];
+      delete data[columnName];
+    }
+  }
+
+  return data;
+}
+
+MongoDB.prototype.fromPropertyToDatabaseNames = function(model, data) {
+  return this.convertColumnNames(model, data, 'database');
+}
+
+MongoDB.prototype.fromDatabaseToPropertyNames = function(model, data) {
+  return this.convertColumnNames(model, data, 'property');
+}
 
 /**
  * Find matching model instances by the filter
@@ -675,7 +771,11 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
     query = self.buildWhere(model, filter.where);
   }
   var fields = filter.fields;
-  if (fields) {
+
+  // Convert custom column names
+  fields = self.fromPropertyToDatabaseNames(model, fields);
+
+  if (fields) {    
     this.execute(model, 'find', query, fields, processResponse);
   } else {
     this.execute(model, 'find', query, processResponse);
@@ -703,7 +803,10 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
         key = key.replace(/\s+(A|DE)SC$/, '').trim();
         if (key === idName) {
           key = '_id';
+        } else {
+          key = self.getDatabaseColumnName(model, key);
         }
+
         if (m && m[1] === 'DE') {
           order[key] = -1;
         } else {
@@ -739,6 +842,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
         if (fields || idName !== '_id') {
           delete o._id;
         }
+
         o = self.fromDatabase(model, o);
         return o;
       });
@@ -819,6 +923,9 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
   var oid = self.coerceId(model, id);
   var idName = this.idName(model);
 
+  // Convert custom column names
+  data = self.fromPropertyToDatabaseNames(model, data);
+
   this.execute(model, 'findAndModify', {_id: oid}, [
     ['_id', 'asc']
   ], data, {}, function (err, result) {
@@ -856,6 +963,9 @@ MongoDB.prototype.update =
 
     // Check for other operators and sanitize the data obj
     data = self.parseUpdateData(model, data, options);
+
+    // Convert custom column names
+    data = self.fromPropertyToDatabaseNames(model, data);
 
     this.execute(model, 'update', where, data, {multi: true, upsert: false},
       function(err, info) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -460,11 +460,11 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
   var oid = self.coerceId(model, id);
   delete data[idName];
 
+  // Convert custom column names (needs to be done prior to extended ops)
+  data = self.fromPropertyToDatabaseNames(model, data);
+
   // Check for other operators and sanitize the data obj
   data = self.parseUpdateData(model, data, options);
-
-  // Convert custom column names
-  data = self.fromPropertyToDatabaseNames(model, data);
 
   this.execute(model, 'findAndModify', {
     _id: oid
@@ -914,6 +914,9 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
 MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, options, cb) {
   var self = this;
 
+  // Convert custom column names (needs to be done prior to extended ops)
+  data = self.fromPropertyToDatabaseNames(model, data);
+
   // Check for other operators and sanitize the data obj
   data = self.parseUpdateData(model, data, options);
 
@@ -922,9 +925,6 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
   }
   var oid = self.coerceId(model, id);
   var idName = this.idName(model);
-
-  // Convert custom column names
-  data = self.fromPropertyToDatabaseNames(model, data);
 
   this.execute(model, 'findAndModify', {_id: oid}, [
     ['_id', 'asc']
@@ -961,11 +961,11 @@ MongoDB.prototype.update =
     where = self.buildWhere(model, where);
     delete data[idName];
 
+    // Convert custom column names (needs to be done prior to extended ops)
+    data = self.fromPropertyToDatabaseNames(model, data);
+
     // Check for other operators and sanitize the data obj
     data = self.parseUpdateData(model, data, options);
-
-    // Convert custom column names
-    data = self.fromPropertyToDatabaseNames(model, data);
 
     this.execute(model, 'update', where, data, {multi: true, upsert: false},
       function(err, info) {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -22,6 +22,17 @@ describe('mongodb connector', function () {
       }
     });
 
+    UserWithRenamedColumns = db.define('UserWithRenamedColumns', {
+      renamedName: { type: String, index: true, mongodb: { column: 'name' } },
+      renamedEmail: { type: String, index: true, unique: true, mongodb: { column: 'email' }  },
+      age: Number,
+      icon: Buffer
+    }, {
+      mongodb: {
+        collection: 'User' // Overlay on the User collection
+      }      
+    });
+
     Superhero = db.define('Superhero', {
       name: { type: String, index: true },
       power: { type: String, index: true, unique: true },
@@ -553,6 +564,32 @@ describe('mongodb connector', function () {
               should.not.exist(err3);
 
               User.updateAll({name: 'Simon'}, {name: 'Alex'}, function(err, updatedusers) {
+                should.not.exist(err);
+                updatedusers.should.have.property('count', 1);
+
+                User.find({where: {name: 'Alex'}}, function(err, founduser) {
+                  should.not.exist(err);
+                  founduser.length.should.be.equal(1);
+                  founduser[0].name.should.be.equal('Alex');
+
+                  done();
+                });
+              });
+
+            });
+          });
+        });
+      });
+      
+      it('should use $set by default if no operator is supplied (using renamed columns)', function(done) {
+        User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(err1, createdusers1) {
+          should.not.exist(err1);
+          User.create({name: 'Simon', age: 32, email: 'simon@strongloop'}, function(err2, createdusers2) {
+            should.not.exist(err2);
+            User.create({name: 'Ray', age: 31, email: 'ray@strongloop'}, function(err3, createdusers3) {
+              should.not.exist(err3);
+
+              UserWithRenamedColumns.updateAll({name: 'Simon'}, {renamedName: 'Alex'}, function(err, updatedusers) {
                 should.not.exist(err);
                 updatedusers.should.have.property('count', 1);
 


### PR DESCRIPTION
Postgresql supports this, but it was missing from Mongodb. See context here:

http://stackoverflow.com/questions/25389102/loopback-mongodb-connector-map-properties-to-field-names
- Works for all execute() combinations, as well as supported in `order` and `filter` criteria clauses, at all depths. 
- Supports overriding the column names using the following priority: `property.mongodb.columnName`, `property.mongodb.column`, `property.columnName`, `property.column`, or the original property name.
- Test cases included, all passing locally.

Thanks. Best.
