### PR TITLE
Add env variable for mongodb server

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -6,7 +6,7 @@ var config = require('rc')('loopback', {test: {mongodb: {}}}).test.mongodb;
 
 if (process.env.CI) {
   config = {
-    host: 'localhost',
+    host: process.env.MONGODB_HOST || 'localhost',
     database: 'lb-ds-mongodb-test-' + (
       process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || '1'
     ),

--- a/test/init.js
+++ b/test/init.js
@@ -7,6 +7,7 @@ var config = require('rc')('loopback', {test: {mongodb: {}}}).test.mongodb;
 if (process.env.CI) {
   config = {
     host: process.env.MONGODB_HOST || 'localhost',
+    port: process.env.MONGODB_PORT || 27017,
     database: 'lb-ds-mongodb-test-' + (
       process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || '1'
     ),


### PR DESCRIPTION
If the MONGODB_HOST variable is set, use that instead of localhost.