### PR TITLE
Implement replaceOrCreate and replaceAttributes

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -494,6 +494,25 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
 };
 
 /**
+ * Replace model instance if it exists or create a new one if it doesn't
+ *
+ * @param {String} model The name of the model
+ * @param {Object} data The model instance data
+ * @param {Object} options The options object
+ * @param {Function} [cb] The callback function
+ */
+MongoDB.prototype.replaceOrCreate = function(model, data, options, cb) {
+  if (this.debug) debug('replaceOrCreate', model, data);
+
+  var id = this.getIdValue(model, data);  
+  var oid = this.coerceId(model, id);
+  var idName = this.idName(model);
+  data._id = data[idName];
+  delete data[idName];
+  this.replaceWithOptions(model, oid, data, {upsert: true}, cb);
+};
+
+/**
  * Delete a model instance by id
  * @param {String} model The model name
  * @param {*} id The id value
@@ -809,6 +828,59 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
       debug('count.callback', model, err, count);
     }
     callback && callback(err, count);
+  });
+};
+
+/**
+ * Replace properties for the model instance data
+ * @param {String} model The name of the model
+ * @param {*} id The instance id
+ * @param {Object} data The model data
+ * @param {Object} options The options object
+ * @param {Function} [cb] The callback function
+ */
+MongoDB.prototype.replaceById = function replace(model, id, data, options, cb) {
+  if (this.debug) debug('replace', model, id, data);
+  var oid = this.coerceId(model, id);
+  this.replaceWithOptions(model, oid, data, {upsert: false}, function(err, data) {
+    cb(err, data);
+  });
+};
+
+/**
+ * Update a model instance with id
+ * @param {String} model The name of the model
+ * @param {Object} id The id of the model instance
+ * @param {Object} data The property/value pairs to be updated or inserted if {upsert: true} is passed as options
+ * @param {Object} options The options you want to pass for update, e.g, {upsert: true}
+ * @callback {Function} [cb] Callback function
+ */
+MongoDB.prototype.replaceWithOptions = function(model, id, data, options, cb) {
+  var self = this;
+  this.execute(model, 'update', {_id: id}, data, options, function(err, info) {
+    if (this.debug) debug('updateWithOptions.callback', model, {_id: id}, data, err, info);
+    if (err)  return cb && cb(err);
+    var result;
+    var cbInfo = {};
+    if (info.result && info.result.n == 1) {
+      result = data;
+      delete result._id;
+      var idName = self.idName(model);
+      result[idName] = id;
+      // create result formats:
+      //   2.4.x :{ ok: 1, n: 1, upserted: [ Object ] }
+      //   { ok: 1, nModified: 0, n: 1, upserted: [ Object ] }
+      //
+      // replace result formats:
+      //   2.4.x: { ok: 1, n: 1 }
+      //   { ok: 1, nModified: 1, n: 1 }
+      if (info.result.nModified !== undefined) {
+        cbInfo.isNewInstance = info.result.nModified === 0;
+      }
+    } else {
+      result = undefined;
+    }
+    cb && cb(err, result, cbInfo);
   });
 };
 

--- a/test/persistence-hooks.test.js
+++ b/test/persistence-hooks.test.js
@@ -14,5 +14,16 @@ if (process.env.MONGODB_VERSION &&
 for(var i in config) {
   customConfig[i] = config[i];
 }
+var DB_VERSION = process.env.MONGODB_VERSION;
 
-suite(global.getDataSource(customConfig), should);
+if (!DB_VERSION) {
+  console.log('The ENV variable MONGODB_VERSION is not set.'
+    + ' Assuming MongoDB version 2.6 or newer.');
+}
+
+var DB_HAS_2_6_FEATURES = (!DB_VERSION ||
+  semver.satisfies(DB_VERSION, '>=2.6.0'));
+
+suite(global.getDataSource(customConfig), should, {
+  replaceOrCreateReportsNewInstance: DB_HAS_2_6_FEATURES
+});


### PR DESCRIPTION
Please See Spike task: https://github.com/strongloop-internal/scrum-loopback/issues/621

##### Added functionality:

*Initial implementation for replaceAttribute
*Initial implementation for replaceOrCreate

##### Other notes:

* These changes are related to the changes in the pull requests under `loopback-connector` and `loopback-datasource-juggler`
* It seems test cases cannot be run on windows machines; I need to dig into it.

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/621

