### PR TITLE
Bug/fix failing test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ OPTS = -G --timeout 10000
 TESTS = test/*.test.js
 
 test:
-	$(TESTER) $(OPTS) $(TESTS)
+	TEST_ENV=local $(TESTER) $(OPTS) $(TESTS)
+test-dev:
+	TEST_ENV=dev $(TESTER) $(OPTS) $(TESTS)
 test-verbose:
 	$(TESTER) $(OPTS) --reporter spec $(TESTS)
 testing:

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -808,6 +808,7 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
  * @param {Function} [callback] The callback function
  */
 MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, options, cb) {
+  console.log(arguments);
   var self = this;
 
   // Check for other operators and sanitize the data obj

--- a/test/init.js
+++ b/test/init.js
@@ -2,7 +2,8 @@ module.exports = require('should');
 
 var DataSource = require('loopback-datasource-juggler').DataSource;
 
-var config = require('rc')('loopback', {test: {mongodb: {}}}).test.mongodb;
+var TEST_ENV = process.env.TEST_ENV || 'test';
+var config = require('rc')('loopback', {test: {mongodb: {}}})[TEST_ENV].mongodb;
 
 if (process.env.CI) {
   config = {


### PR DESCRIPTION
@raymondfeng @bajtos This fixes all the tests, which have been failing for awhile (did a few checkouts to see when the last all green was). Anyways, the fail is related to https://github.com/strongloop/loopback-connector-mysql/issues/130#issuecomment-163056499. Strict mode is stripping out the test object to show `{}` again, causing the tests to create bad queries (we need to implement better validation here, but waiting for the discussion to continue over in the other issue). Anyways, gonna merge without review when CI passes.