### PR TITLE
test: fix order of semver arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "benchmarks": "make benchmarks",
     "leak-detection": "make leak-detection",
-    "test": "make test"
+    "test": "mocha -G --timeout 10000 test/*.test.js"
   },
   "dependencies": {
     "loopback-connector": "^2.2.0",

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1,4 +1,5 @@
 // This test written in mocha+should.js
+var semver = require('semver');
 var should = require('./init.js');
 
 var Superhero, User, Post, PostWithStringId, db;
@@ -527,8 +528,7 @@ describe('mongodb connector', function () {
 
     var describeMongo26 = describe;
     if (process.env.MONGODB_VERSION &&
-      require('semver').satisfies('2.6.0', '>' +
-        process.env.MONGODB_VERSION)) {
+        !semver.satisfies(process.env.MONGODB_VERSION, '~2.6.0')) {
       describeMongo26 = describe.skip;
     }
 

--- a/test/persistence-hooks.test.js
+++ b/test/persistence-hooks.test.js
@@ -1,3 +1,4 @@
+var semver = require('semver');
 var should = require('./init');
 var suite = require('loopback-datasource-juggler/test/persistence-hooks.suite.js');
 
@@ -6,8 +7,7 @@ var customConfig = {
 };
 
 if (process.env.MONGODB_VERSION &&
-  require('semver').satisfies('2.6.0', '>' +
-    process.env.MONGODB_VERSION)) {
+    semver.satisfies(process.env.MONGODB_VERSION, '>= 2.6.0')) {
   customConfig.enableOptimisedfindOrCreate = true;
 }
 


### PR DESCRIPTION
The tests were being enabled for any version of mongo older than 2.6.0,
not newer.

Also changes `npm test` to run `mocha` directly, which lets our CI properly detect and modify the arguments. This allows for such novel things as:
 - test reports
 - code coverage
 - test count trends