### PR TITLE
Fix warning UNMET PEER DEPENDENCY kerberos@~0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,9 @@
   "license": "MIT",
   "dependencies": {
     "loopback-connector": "^2.2.0",
-    "mongodb": "~2.0.35",
+    "mongodb": "^2.0.35",
     "async": "^1.0.0",
-    "debug": "^2.1.1",
-    "kerberos": "~0.0.21"
+    "debug": "^2.1.1"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "loopback-connector": "^2.2.0",
     "mongodb": "~2.0.35",
     "async": "^1.0.0",
-    "debug": "^2.1.1"
+    "debug": "^2.1.1",
+    "kerberos": "0.0.21"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mongodb": "~2.0.35",
     "async": "^1.0.0",
     "debug": "^2.1.1",
-    "kerberos": "0.0.21"
+    "kerberos": "~0.0.21"
   },
   "devDependencies": {
     "benchmark": "^1.0.0",


### PR DESCRIPTION
As the title says, this fixes the warning you get when you `npm install` this connector.