### PR TITLE
GeoPoint update fix for updateAttributes()

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -240,6 +240,12 @@ MongoDB.prototype.toDatabase = function(model, data) {
         type: 'Point',
       };
     }
+    else if (data['$set'] && data['$set'][p] && prop && prop.type && prop.type.name === 'GeoPoint') {
+      data['$set'][p] = {
+        coordinates: [data['$set'][p].lng, data['$set'][p].lat],
+        type: 'Point',
+      };
+    }
   }
 
   return data;


### PR DESCRIPTION
When updating a geopoint field via `Model.updateAttributes()`, it passes the data wrapped in `$set` instead of a direct object which is expected by the `toDatabase()` call.
