### PR TITLE
Check for connector enabled / disabled option

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -65,6 +65,10 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 
   var s = dataSource.settings;
 
+  if (s.enabled === false) {
+    return;
+  }
+
   s.safe = (s.safe !== false);
   s.w = s.w || 1;
   s.url = s.url || generateMongoDBURL(s);


### PR DESCRIPTION
Further to https://github.com/strongloop/loopback-connector-mongodb/issues/256, I've added a tiny check for a "enabled" option in the datasources, so that you can disable a particular datasource if you have multiple sources but want to swap between them, to allow the app to start up without failing to connect to the sources that are not in use.

 "mongodb": {
    "host": "localhost",
    "port": 27017,
    "url": "",
    "database": "users",
    "password": "",
    "name": "mongodb",
    "user": "",
    "connector": "mongodb",
    **"enabled": false**
  },