### PR TITLE
Use the latest compatible mongodb 

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "loopback-connector": "^2.2.0",
-    "mongodb": "2.1.21",
+    "mongodb": "~2.1.21",
     "async": "^1.0.0",
     "debug": "^2.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "loopback-connector": "^2.2.0",
-    "mongodb": "^2.0.35",
+    "mongodb": "2.1.21",
     "async": "^1.0.0",
     "debug": "^2.1.1"
   },

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -38,7 +38,7 @@ describe('lazyConnect', function() {
     });
 
     ds.on('error', function(err) {
-      err.message.should.containEql('ECONNREFUSED');
+      err.message.should.match(/connect ECONNREFUSED/);
       done();
     });
   });


### PR DESCRIPTION
mongodb changed their error message in version 2.2.x

This is a fix for CI failure:
```
1) lazyConnect should report connection error (lazyConnect = false):
     Uncaught AssertionError: expected 'failed to connect to server [127.0.0.1:4] on first connect' to contain 'ECONNREFUSED'
      at Assertion.fail (node_modules/should/lib/assertion.js:92:17)
      at Assertion.Object.defineProperty.value [as containEql] (node_modules/should/lib/assertion.js:164:19)
      at DataSource.<anonymous> (test/mongodb.test.js:41:26)
      at DataSource.postInit (node_modules/loopback-datasource-juggler/lib/datasource.js:329:14)
      at lib/mongodb.js:148:19
      at node_modules/mongodb/lib/mongo_client.js:245:20
      at node_modules/mongodb/lib/db.js:227:14
      at [object Object].<anonymous> (node_modules/mongodb/lib/server.js:228:9)
      at [object Object].<anonymous> (node_modules/mongodb-core/lib/topologies/server.js:289:21)
      at [object Object].<anonymous> (node_modules/mongodb-core/lib/connection/pool.js:230:12)
      at Socket.<anonymous> (node_modules/mongodb-core/lib/connection/connection.js:150:49)
      at emitErrorNT (net.js:1265:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
  ---------------------------------------------
      at Context.<anonymous> (test/mongodb.test.js:40:8)

  2) mongodb connector .ping(cb) should report connection errors:
     Uncaught AssertionError: expected 'failed to connect to server [localhost:4] on first connect' to match /connect ECONNREFUSED/
      at Assertion.fail (node_modules/should/lib/assertion.js:92:17)
      at Assertion.Object.defineProperty.value [as match] (node_modules/should/lib/assertion.js:164:19)
      at test/mongodb.test.js:155:28
      at DataSource.<anonymous> (lib/mongodb.js:1245:7)
      at DataSource.postInit (node_modules/loopback-datasource-juggler/lib/datasource.js:329:14)
      at lib/mongodb.js:148:19
      at node_modules/mongodb/lib/mongo_client.js:245:20
      at node_modules/mongodb/lib/db.js:227:14
      at [object Object].<anonymous> (node_modules/mongodb/lib/server.js:228:9)
      at [object Object].<anonymous> (node_modules/mongodb-core/lib/topologies/server.js:289:21)
      at [object Object].<anonymous> (node_modules/mongodb-core/lib/connection/pool.js:230:12)
      at Socket.<anonymous> (node_modules/mongodb-core/lib/connection/connection.js:150:49)
      at emitErrorNT (net.js:1265:8)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
  ---------------------------------------------
      at MongoDB.ping (lib/mongodb.js:1244:21)
      at DataSource.ping (node_modules/loopback-datasource-juggler/lib/datasource.js:2148:20)
      at Context.<anonymous> (test/mongodb.test.js:153:10)
```
http://ci.strongloop.com/job/loopback-connector-mongodb/1364/label=amazon-5/console