### PR TITLE
Support for searches with logical operators and $maxDistance 

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -734,8 +734,13 @@ MongoDB.prototype.buildSort = function(model, order) {
 };
 
 function buildNearFilter(query, near) {
+  var node = query.where;
+  near.key.forEach(function(key) {
+    node = node[key];
+  });
+
   var coordinates = {};
-  if (typeof near.near === 'string') {
+  if (typeof node.near === 'string') {
     var s = near.near.split(',');
 
     coordinates.lng = Number(s[0]);
@@ -744,26 +749,42 @@ function buildNearFilter(query, near) {
     coordinates = near.near;
   }
 
-  query.where[near.key] = {
-    near: {
-      $geometry: {
-        coordinates: [coordinates.lng, coordinates.lat],
-        type: 'Point',
-      },
+  node.near = {
+    $geometry: {
+      coordinates: [coordinates.lng, coordinates.lat],
+      type: 'Point',
     },
   };
-};
+
+  if (near.maxDistance) {
+    node.near['$maxDistance'] = near.maxDistance;
+  }
+}
 
 function hasNearFilter(where) {
   if (!where) return false;
 
-  for (var k in where) {
-    if (where[k] && typeof where[k] === 'object' && where[k].near) {
-      return true;
-    }
-  }
+  var found = false;
+  var keyPath = [];
+  searchForNear(where);
 
-  return false;
+  function searchForNear(node) {
+    if (node && typeof node === 'object') {
+      var keys = Object.keys(node);
+      for (var i = 0; i < keys.length; i++) {
+        var ex = node[keys[i]];
+        keyPath.push(keys[i]);
+        if (ex && ex.near) {
+          found = true;
+          return false;
+        } else {
+          return searchForNear(ex);
+        }
+      }
+    }
+    return false;
+  }
+  return found;
 }
 
 /**

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -765,24 +765,21 @@ function hasNearFilter(where) {
   if (!where) return false;
 
   var found = false;
-  var keyPath = [];
+
   searchForNear(where);
 
   function searchForNear(node) {
     if (node && typeof node === 'object') {
-      var keys = Object.keys(node);
-      for (var i = 0; i < keys.length; i++) {
-        var ex = node[keys[i]];
-        keyPath.push(keys[i]);
-        if (ex && ex.near) {
+      Object.keys(node).forEach(function(key) {
+        var nodeProperty = node[key];
+
+        if (nodeProperty && nodeProperty.near) {
           found = true;
-          return false;
         } else {
-          return searchForNear(ex);
+          searchForNear(nodeProperty);
         }
-      }
+      });
     }
-    return false;
   }
   return found;
 }

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1466,7 +1466,7 @@ describe('mongodb connector', function() {
           createPost.bind(null),
           createPost.bind(null),
         ], function(err) {
-          should.not.exist(err);
+          if (err) return done(err);
 
           PostWithLocation.find({
             where: {
@@ -1482,7 +1482,7 @@ describe('mongodb connector', function() {
               ],
             },
           }, function(err, results) {
-            should.not.exist(err);
+            if (err) return done(err);
             should.exist(results);
             results.length.should.be.exactly(1);
 
@@ -1519,7 +1519,7 @@ describe('mongodb connector', function() {
             }, callback);
           },
         ], function(err) {
-          should.not.exist(err);
+          if (err) return done(err);
 
           async.parallel([
             // test maxDistance with logical operator
@@ -1539,7 +1539,7 @@ describe('mongodb connector', function() {
                   ],
                 },
               }, function(err, results) {
-                should.not.exist(err);
+                if (err) return done(err);
                 should.exist(results);
                 results.length.should.be.exactly(1);
 
@@ -1565,7 +1565,7 @@ describe('mongodb connector', function() {
                   },
                 },
               }, function(err, results) {
-                should.not.exist(err);
+                if (err) return done(err);
                 should.exist(results);
                 results.length.should.be.exactly(1);
 
@@ -1582,7 +1582,7 @@ describe('mongodb connector', function() {
               });
             },
           ], function(err) {
-            should.not.exist(err);
+            if (err) return done(err);
             done();
           });
         });

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1374,6 +1374,7 @@ describe('mongodb connector', function() {
       PostWithLocation = geoDb.define('PostWithLocation', {
         _id: { type: geoDb.ObjectID, id: true },
         location: { type: GeoPoint, index: true },
+        title: { type: String },
       });
     });
 
@@ -1432,6 +1433,156 @@ describe('mongodb connector', function() {
               dist = currentDist;
             });
 
+            done();
+          });
+        });
+      });
+    });
+
+    it('find should be able to query by location with logical operator', function(done) {
+      var coords = { lat: 1.25, lng: 20.20 };
+      var title = 'geoWithLogicalOperatorTest';
+
+      geoDb.autoupdate(function(err) {
+        var titleIndex = 0;
+
+        var createPost = function(callback) {
+          var point = new GeoPoint({
+            lat: (Math.random() * 180) - 90,
+            lng: (Math.random() * 360) - 180,
+          });
+
+          PostWithLocation.create({
+            location: point,
+            title: title + titleIndex,
+          }, callback);
+
+          titleIndex++;
+        };
+
+        async.parallel([
+          createPost.bind(null),
+          createPost.bind(null),
+          createPost.bind(null),
+          createPost.bind(null),
+        ], function(err) {
+          should.not.exist(err);
+
+          PostWithLocation.find({
+            where: {
+              and: [
+                {
+                  location: {
+                    near: new GeoPoint(coords),
+                  },
+                },
+                {
+                  title: title + '0',
+                },
+              ],
+            },
+          }, function(err, results) {
+            should.not.exist(err);
+            should.exist(results);
+            results.length.should.be.exactly(1);
+
+            var dist = 0;
+            results.forEach(function(result) {
+              var currentDist = testUtils.getDistanceBetweenPoints(coords, result.location);
+              currentDist.should.be.aboveOrEqual(dist);
+
+              result.title.should.be.exactly(title + '0');
+
+              dist = currentDist;
+            });
+
+            done();
+          });
+        });
+      });
+    });
+
+    it('find should be able to query by location with maxDistance', function(done) {
+      var coords = { lat: 33.801463, lng: -118.341724 };
+      var title = 'geoWithLogicalOperatorTest';
+
+      geoDb.autoupdate(function(err) {
+        async.parallel([
+          function(callback) {
+            PostWithLocation.create({
+              location: new GeoPoint({ lat: 33.801368, lng: -118.341697 }), title: title,
+            }, callback);
+          },
+          function(callback) {
+            PostWithLocation.create({
+              location: new GeoPoint({ lat: 31.704320, lng: 35.207651 }), title: title,
+            }, callback);
+          },
+        ], function(err) {
+          should.not.exist(err);
+
+          async.parallel([
+            // test maxDistance with logical operator
+            function(callback) {
+              PostWithLocation.find({
+                where: {
+                  and: [
+                    {
+                      location: {
+                        near: new GeoPoint(coords),
+                        maxDistance: Number(Math.round(5 * 1609.34).toFixed(2)), // miles to meters
+                      },
+                    },
+                    {
+                      title: title,
+                    },
+                  ],
+                },
+              }, function(err, results) {
+                should.not.exist(err);
+                should.exist(results);
+                results.length.should.be.exactly(1);
+
+                var dist = 0;
+                results.forEach(function(result) {
+                  var currentDist = testUtils.getDistanceBetweenPoints(coords, result.location);
+                  currentDist.should.be.aboveOrEqual(dist);
+
+                  result.title.should.be.exactly(title);
+
+                  dist = currentDist;
+                });
+                callback();
+              });
+            },
+            // test maxDistance without logical operator
+            function(callback) {
+              PostWithLocation.find({
+                where: {
+                  location: {
+                    near: new GeoPoint(coords),
+                    maxDistance: Number(Math.round(5 * 1609.34).toFixed(2)), // miles to meters
+                  },
+                },
+              }, function(err, results) {
+                should.not.exist(err);
+                should.exist(results);
+                results.length.should.be.exactly(1);
+
+                var dist = 0;
+                results.forEach(function(result) {
+                  var currentDist = testUtils.getDistanceBetweenPoints(coords, result.location);
+                  currentDist.should.be.aboveOrEqual(dist);
+
+                  result.title.should.be.exactly(title);
+
+                  dist = currentDist;
+                });
+                callback();
+              });
+            },
+          ], function(err) {
+            should.not.exist(err);
             done();
           });
         });


### PR DESCRIPTION
Fix #271

Requires PR: https://github.com/strongloop/loopback-datasource-juggler/pull/1036

Updated `buildNearFilter` to account for changes to juggler's nearFilter. Added support for logical operators and $maxDistance.
