### PR TITLE
Bind context where it was lost

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -54,6 +54,21 @@ function generateMongoDBURL(options) {
   }
 }
 
+/*!
+ * Tries to get the context and patch the function passed as argument
+ * @param {Function} the function to patch
+ * @param {String} [scopeName=loopback] the scope name
+ * @returns {Function} the function patched
+ */
+function patchWithContext(fn, scopeName) {
+  scopeName = scopeName || 'loopback';
+  var ns = process && process.context && process.context[scopeName];
+  if (ns && ns.bind) {
+    fn = ns.bind(fn);
+  }
+  return fn;
+}
+
 /**
  * Initialize the MongoDB connector for the given data source
  * @param {DataSource} dataSource The data source instance
@@ -847,7 +862,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
     } else if (filter.offset) {
       cursor.skip(filter.offset);
     }
-    cursor.toArray(function(err, data) {
+    cursor.toArray(patchWithContext(function(err, data) {
       if (self.debug) {
         debug('all', model, filter, err, data);
       }
@@ -870,7 +885,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
       } else {
         callback(null, objs);
       }
-    });
+    }));
   }
 };
 
@@ -1000,7 +1015,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
 
   this.execute(model, 'findAndModify', { _id: oid }, [
     ['_id', 'asc'],
-  ], data, {}, function(err, result) {
+  ], data, {}, patchWithContext(function(err, result) {
     if (self.debug) {
       debug('updateAttributes.callback', model, id, err, result);
     }
@@ -1012,7 +1027,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(model, id, data, optio
     self.setIdValue(model, object, id);
     object && idName !== '_id' && delete object._id;
     cb && cb(err, object);
-  });
+  }));
 };
 
 /**

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -273,6 +273,7 @@ MongoDB.prototype.execute = function(model, command) {
   var args = [].slice.call(arguments, 2);
   // The last argument must be a callback function
   var callback = args[args.length - 1];
+  callback = patchWithContext(callback);
   var context = {
     model: model,
     collection: collection, req: {


### PR DESCRIPTION
I had issues ([loopback#2597](https://github.com/strongloop/loopback/issues/2597), [loopback#2603](https://github.com/strongloop/loopback/issues/2603)) where I was losing context.

One solution was the usage of cls-hooked instead of cls on loopback-context as proposed by @josieusa [here](https://github.com/strongloop/loopback-context/pull/2) and that solved the issue. But when using the mongo connector, sometimes the context was losing.

I propose to patch two functions with context if available. For me this solve all my issues. I don't know if this will have downsides, but for me works always fine and all tests are passed.

PS: This is my first PR and english isn't my first language, so sorry if there are some mistakes. :sweat_smile: 