### PR TITLE
Remove TEST prefix for env vars

### DIFF
--- a/test/init.js
+++ b/test/init.js
@@ -12,8 +12,8 @@ var config = require('rc')('loopback', { test: { mongodb: {}}})[TEST_ENV].mongod
 
 if (process.env.CI) {
   config = {
-    host: process.env.TEST_MONGODB_HOST || 'localhost',
-    port: process.env.TEST_MONGODB_PORT || 27017,
+    host: process.env.MONGODB_HOST || 'localhost',
+    port: process.env.MONGODB_PORT || 27017,
     database: 'lb-ds-mongodb-test-' + (
       process.env.TRAVIS_BUILD_NUMBER || process.env.BUILD_NUMBER || '1'
     ),


### PR DESCRIPTION
* TEST_ prefix is not used by CI anymore and there for serve no purpose

* Part of overall goal to standardize env var injection to
  MODULE_VARNAME (ie. MONGODB_HOST for example) convention

cc @bajtos @strongloop/fa-db-connectors 