### PR TITLE
Build near filter when key is an array

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -819,45 +819,111 @@ function convertToMeters(distance, unit) {
   }
 }
 
-function buildNearFilter(query, near) {
-  var coordinates = {};
-  if (typeof near.near === 'string') {
-    var s = near.near.split(',');
-    coordinates.lng = Number(s[0]);
-    coordinates.lat = Number(s[1]);
-  } else {
-    coordinates = near.near;
+function buildNearFilter(query, params) {
+  if (!Array.isArray(params)) {
+    params = [params];
   }
 
-  query.where[near.key] = {
-    near: {
-      $geometry: {
-        coordinates: [coordinates.lng, coordinates.lat],
-        type: 'Point',
-      },
-    },
-  };
+  params.forEach(function(near) {
+    var coordinates = {};
 
-  var props = ['maxDistance', 'minDistance'];
-  //use mongodb default unit 'meters' rather than 'miles'
-  var unit = near.unit || 'meters';
-  props.forEach(function(p) {
-    if (near[p]) {
-      query.where[near.key]['near']['$' + p] = convertToMeters(near[p], unit);
+    if (typeof near.near === 'string') {
+      var s = near.near.split(',');
+      coordinates.lng = parseFloat(s[0]);
+      coordinates.lat = parseFloat(s[1]);
+    } else if (Array.isArray(near.near)) {
+      coordinates.lng = near.near[0];
+      coordinates.lat = near.near[1];
+    } else {
+      coordinates = near.near;
+    }
+
+    var props = ['maxDistance', 'minDistance'];
+    // use mongodb default unit 'meters' rather than 'miles'
+    var unit = near.unit || 'meters';
+
+    var queryValue = {
+      near: {
+        $geometry: {
+          coordinates: [coordinates.lng, coordinates.lat],
+          type: 'Point',
+        },
+      },
+    };
+
+    props.forEach(function(p) {
+      if (near[p]) {
+        queryValue.near['$' + p] = convertToMeters(near[p], unit);
+      }
+    });
+
+    var property;
+
+    if (near.mongoKey) {
+      // if mongoKey is an Array, set the $near query at the right depth, following the Array
+      if (Array.isArray(near.mongoKey)) {
+        property = query.where;
+
+        for (var i = 0; i < near.mongoKey.length; i++) {
+          var subKey = near.mongoKey[i];
+
+          if (near.mongoKey.hasOwnProperty(i + 1)) {
+            if (!property.hasOwnProperty(subKey)) {
+              property[subKey] = Number.isInteger(near.mongoKey[i + 1]) ? [] : {};
+            }
+
+            property = property[subKey];
+          }
+        }
+
+        property[near.mongoKey[i - 1]] = queryValue;
+      } else {
+        // mongoKey is a single string, just set it directly
+        property = query.where[near.mongoKey] = queryValue;
+      }
     }
   });
 };
 
 function hasNearFilter(where) {
   if (!where) return false;
+  // TODO: Optimize to return once a `near` key is found
+  // instead of searching through everything
 
-  for (var k in where) {
-    if (where[k] && typeof where[k] === 'object' && where[k].near) {
-      return true;
-    }
+  var isFound = false;
+
+  searchForNear(where);
+
+  function found(prop) {
+    return prop && prop.near;
   }
 
-  return false;
+  function searchForNear(node) {
+    if (!node) {
+      return;
+    }
+
+    if (Array.isArray(node)) {
+      node.forEach(function(prop) {
+        isFound = found(prop);
+
+        if (!isFound) {
+          searchForNear(prop);
+        }
+      });
+    } else if (typeof node === 'object') {
+      Object.keys(node).forEach(function(key) {
+        var prop = node[key];
+
+        isFound = found(prop);
+
+        if (!isFound) {
+          searchForNear(prop);
+        }
+      });
+    }
+  }
+  return isFound;
 }
 
 MongoDB.prototype.getDatabaseColumnName = function(model, propName) {


### PR DESCRIPTION
Fix `buildNearFilter` to work with any key depth

### Description

When building a `$near` filter, keys can have different depth. To make the filter work properly, this needs to be handled properly.

So here's a fix for that.

NOTE: This comes after a fix for strongloop/loopback-datasource-juggler to handle deep `geo.nearFilter` search

#### Related issues

- Makes required strongloop/loopback-datasource-juggler#1216 (related to strongloop/loopback-datasource-juggler#993) fix work fully on MongoDB

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)