### PR TITLE
Delete extraneous `id` for replacById

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1071,6 +1071,8 @@ MongoDB.prototype.replaceById = function replace(model, id, data, options, cb) {
  */
 MongoDB.prototype.replaceWithOptions = function(model, id, data, options, cb) {
   var self = this;
+  var idName = self.idName(model);
+  delete data[idName];
   this.execute(model, 'update', { _id: id }, data, options, function(err, info) {
     if (this.debug) debug('updateWithOptions.callback', model, { _id: id }, data, err, info);
     if (err)  return cb && cb(err);
@@ -1079,7 +1081,6 @@ MongoDB.prototype.replaceWithOptions = function(model, id, data, options, cb) {
     if (info.result && info.result.n == 1) {
       result = data;
       delete result._id;
-      var idName = self.idName(model);
       result[idName] = id;
       // create result formats:
       //   2.4.x :{ ok: 1, n: 1, upserted: [ Object ] }


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback/issues/2926

This patch deletes an extraneous `id` field when `replaceById` is used. Please note this patch cannot have test cases, since all test cases should go to `loopback-datasource-juggler`

@strongloop/sq-lb-apex Since you are the owner of `loopback-datasource-juggler` and connectors, I assign this to you to review and land. Thanks!