### PR TITLE
updated mongodb version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "^1.0.0",
     "debug": "^2.1.1",
     "loopback-connector": "^2.2.0",
-    "mongodb": "^2.1.21",
+    "mongodb": "^2.2.0",
     "strong-globalize": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description
Updating mongodb version from "^2.1.21" to "^2.2.0".  The version of loopback-connector-mongodb our application is using had the version set to "~2.1.21" prior to our change.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
