### PR TITLE
Mongo 3.4 Support/Delete index ‘kind’ property from index options

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1264,7 +1264,7 @@ MongoDB.prototype.autoupdate = function(models, cb) {
               options = properties[p].index.mongodb;
               index[p] = options.kind || 1;
 
-              // If 'kind' is set delete it so it isn't accidentally inserted as an index option 
+              // If 'kind' is set delete it so it isn't accidentally inserted as an index option
               if (options.kind) {
                 delete options.kind;
               }

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1264,6 +1264,11 @@ MongoDB.prototype.autoupdate = function(models, cb) {
               options = properties[p].index.mongodb;
               index[p] = options.kind || 1;
 
+              // If 'kind' is set delete it so it isn't accidentally inserted as an index option 
+              if (options.kind) {
+                delete options.kind;
+              }
+
               // Backwards compatibility for former type of indexes
               if (properties[p].index.unique === true) {
                 options.unique = true;


### PR DESCRIPTION
### Description
Ran into a broken test when setting up locally to write another PR. As I explain below, it's related to changes in MongoDB 3.4.

The test in question is:
`mongodb connector -> should create complex indexes`
Which tests complex indexes such as `2dsphere`

`AutoUpdate` uses the entire `model.property.index.mongodb` object as options when creating an index.
If used this leaves the 'kind' property in the index options which causes MongoDB to throw the following error:

```
MongoError: The field 'kind' is not valid for an index specification. Specification:
{
  ns: "lb-ds-mongodb-test.sh",
  key: { geometry: "2dsphere" },
  name: "geometry_2dsphere",
  kind: "2dsphere",
  background: true,
  unique: false 
}
```

I did some research and it seems that this was caused by an update to indexes in MongoDB 3.4

I've run the test suite on MongoDB 3.2 & 3.4 and all tests pass on both :)

#### Related issues
None that I can see

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
