### PR TITLE
mongodb version locked to 2.2.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "async": "^1.0.0",
     "debug": "^2.1.1",
     "loopback-connector": "^3.0.0",
-    "mongodb": "^2.1.21",
+    "mongodb": "2.2.22",
     "strong-globalize": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Related issues

strongloop/loopback-connector-mongodb#344

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
