### PR TITLE
Omit invalid mongodb options

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -135,7 +135,19 @@ MongoDB.prototype.connect = function(callback) {
       });
     });
   } else {
-    mongodb.MongoClient.connect(self.settings.url, self.settings, function(err, db) {
+    // omit invalid mongodb options, otherwise mongodb@ >= 2.2.23 will exit with error
+    var settings = {};
+    for (var p in self.settings) {
+      if (
+        ['allowExtendedOperators', 'connector', 'database', 'debug',
+          'enableGeoIndexing', 'enableOptimisedfindOrCreate', 'host', 'hostname',
+          'lazyConnect', 'port', 'safe', 'url'].indexOf(p) === -1
+      ) {
+        settings[p] = self.settings[p];
+      }
+    }
+
+    mongodb.MongoClient.connect(self.settings.url, settings, function(err, db) {
       if (!err) {
         if (self.debug) {
           debug('MongoDB connection is established: ' + self.settings.url);


### PR DESCRIPTION
### Description

https://github.com/mongodb/node-mongodb-native/commit/39102e11d6c905986b0971a49ace2afb770d87b2 introduces strict option validation which is incompatible with loopback settings object, such causing the server not to start.
The affected settings are now omited in the settings which are passed to the mongodb driver.

I had some emails exchange with christkv@gmail.com and he stated that the changes in mongodb@2.2.23 will be permanent. 

#### Related issues

- None

### Checklist

- [-] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
