### PR TITLE
Remove invalid options

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -135,7 +135,24 @@ MongoDB.prototype.connect = function(callback) {
       });
     });
   } else {
-    mongodb.MongoClient.connect(self.settings.url, self.settings, function(err, db) {
+    var validOptionNames = ['poolSize', 'ssl', 'sslValidate', 'sslCA', 'sslCert',
+   'sslKey', 'sslPass', 'autoReconnect', 'noDelay', 'keepAlive', 'connectTimeoutMS',
+   'socketTimeoutMS', 'reconnectTries', 'reconnectInterval', 'ha', 'haInterval',
+   'replicaSet', 'secondaryAcceptableLatencyMS', 'acceptableLatencyMS',
+   'connectWithNoPrimary', 'authSource', 'w', 'wtimeout', 'j', 'forceServerObjectId',
+   'serializeFunctions', 'ignoreUndefined', 'raw', 'promoteLongs', 'bufferMaxEntries',
+   'readPreference', 'pkFactory', 'promiseLibrary', 'readConcern', 'maxStalenessSeconds',
+   'loggerLevel', 'logger', 'promoteValues', 'promoteBuffers', 'promoteLongs',
+   'domainsEnabled', 'keepAliveInitialDelay', 'checkServerIdentity'];
+    var lbOptions = Object.keys(self.settings);
+    var validOptions = {};
+    lbOptions.forEach(function(option) {
+      if (validOptionNames.indexOf(option) > -1) {
+        validOptions[option] = self.settings[option];
+      }
+    });
+    debug('Valid options: %j' + validOptions);
+    mongodb.MongoClient.connect(self.settings.url, validOptions, function(err, db) {
       if (!err) {
         if (self.debug) {
           debug('MongoDB connection is established: ' + self.settings.url);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -175,7 +175,7 @@ describe('mongodb connector', function() {
       db.ping(done);
     });
 
-    it('should report connection errors', function(done) {
+    it('should report connection errors with invalid config', function(done) {
       var ds = getDataSource({
         host: 'localhost',
         port: 4, // unassigned by IANA
@@ -185,6 +185,13 @@ describe('mongodb connector', function() {
         err.message.should.match(/failed to connect to server/);
         done();
       });
+    });
+
+    it('ignores invalid option', function(done) {
+      var configWithInvalidOption = config;
+      configWithInvalidOption.invalidOption = 'invalid';
+      var ds = getDataSource(configWithInvalidOption);
+      ds.ping(done);
     });
   });
 


### PR DESCRIPTION
Connect to https://github.com/strongloop/loopback-connector-mongodb/issues/344

In the latest version of mongodb@2.2.23, invalid options are not allowed to passed into the driver, [this pr](https://github.com/mongodb/node-mongodb-native/commit/39102e11d6c905986b0971a49ace2afb770d87b2#diff-af7f90364fd34f588f43f92c13a92ab6R29) defines all valid options.

Not sure if `mongodb` provides an api to validate an option, from the pr above that api doesn't exist, need some time to investigate a better way to do validation. As a workaround, I manually copied all valid options in to our code to do the check.