### PR TITLE
Export the MongoDB function to allow subclassing

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -13,6 +13,7 @@ var async = require('async');
 var Connector = require('loopback-connector').Connector;
 var debug = require('debug')('loopback:connector:mongodb');
 
+exports.ObjectID = ObjectID;
 /*!
  * Convert the id to be a BSON ObjectID if it is compatible
  * @param {*} id The id value
@@ -39,6 +40,7 @@ function ObjectID(id) {
   }
 }
 
+exports.generateMongoDBURL = generateMongoDBURL;
 /*!
  * Generate the mongodb URL from the options
  */
@@ -83,7 +85,9 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 };
 
-/**
+exports.MongoDB = MongoDB;
+
+  /**
  * The constructor for MongoDB connector
  * @param {Object} settings The settings object
  * @param {DataSource} dataSource The data source instance

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2013,6 +2013,21 @@ describe('mongodb connector', function() {
     });
   });
 
+  it('should export the MongoDB function', function() {
+    var module = require('../');
+    module.MongoDB.should.be.an.instanceOf(Function);
+  });
+
+  it('should export the ObjectID function', function() {
+    var module = require('../');
+    module.ObjectID.should.be.an.instanceOf(Function);
+  });
+
+  it('should export the generateMongoDBURL function', function() {
+    var module = require('../');
+    module.generateMongoDBURL.should.be.an.instanceOf(Function);
+  });
+
   context('regexp operator', function() {
     before(function deleteExistingTestFixtures(done) {
       Post.destroyAll(done);


### PR DESCRIPTION
### Description
Export the MongoDB function to allow easy subclassing. This is [already done](https://github.com/strongloop/loopback-connector-mysql/blob/master/lib/mysql.js#L48) in the MySQL connector and is referenced [in the docs](https://loopback.io/doc/en/lb3/Building-a-connector.html) as the best way to extend a connector.

#### Related issues
- None

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
