### PR TITLE
Fix lazy connect

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -280,31 +280,55 @@ MongoDB.prototype.toDatabase = function(model, data) {
  * @param [...] params Parameters for the given command
  */
 MongoDB.prototype.execute = function(model, command) {
-  var collection = this.collection(model);
+  var self = this;
   // Get the parameters for the given command
   var args = [].slice.call(arguments, 2);
   // The last argument must be a callback function
   var callback = args[args.length - 1];
-  var context = {
-    model: model,
-    collection: collection, req: {
-      command: command,
-      params: args,
-    },
-  };
-  this.notifyObserversAround('execute', context, function(context, done) {
-    args[args.length - 1] = function(err, result) {
+
+  if (self.db) {
+    doExecute();
+  } else {
+    self.connect(function(err, db) {
       if (err) {
-        debug('Error: ', err);
-      } else {
-        context.res = result;
-        debug('Result: ', result);
+        debug('Connection not established - MongoDB: model=%s command=%s -- error=%s', model, command, err);
       }
-      done(err, result);
+      doExecute();
+    });
+  }
+
+  function doExecute() {
+    var collection;
+    var context = {
+      model: model,
+      collection: collection, req: {
+        command: command,
+        params: args,
+      },
     };
-    debug('MongoDB: model=%s command=%s', model, command, args);
-    return collection[command].apply(collection, args);
-  }, callback);
+
+    try {
+      var collection = self.collection(model);
+    } catch (err) {
+      debug('Error: ', err);
+      callback(err);
+      return;
+    }
+
+    self.notifyObserversAround('execute', context, function(context, done) {
+      args[args.length - 1] = function(err, result) {
+        if (err) {
+          debug('Error: ', err);
+        } else {
+          context.res = result;
+          debug('Result: ', result);
+        }
+        done(err, result);
+      };
+      debug('MongoDB: model=%s command=%s', model, command, args);
+      return collection[command].apply(collection, args);
+    }, callback);
+  }
 };
 
 MongoDB.prototype.coerceId = function(model, id) {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -44,6 +44,26 @@ describe('lazyConnect', function() {
       done();
     });
   });
+
+  it('should connect on execute (lazyConnect = true)', function(done) {
+    var ds = getDataSource({
+      host: '127.0.0.1',
+      port: config.port,
+      lazyConnect: true,
+    });
+
+    ds.define('TestLazy', {
+      value: { type: String },
+    });
+
+    ds.connector.execute('TestLazy', 'insert', { 'value': 'test value' }, function(err, success) {
+      if (err) {
+        done(err);
+      } else {
+        done();
+      }
+    });
+  });
 });
 
 describe('mongodb connector', function() {


### PR DESCRIPTION
### Description

When setting lazyConnect we should be able to start the server with or without the database available. Also, if the db server goes down, requests should show the error rather than crash the server. When the db comes back up, requests should continue working again as before. Modified execute to support this.