### PR TITLE
Reconnect on execute after disconnect.

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -286,9 +286,15 @@ MongoDB.prototype.execute = function(model, command) {
   // The last argument must be a callback function
   var callback = args[args.length - 1];
 
-  if (self.db) {
+  // Topology is destroyed when the server is disconnected
+  // Execute if DB is connected and functional otherwise connect/reconnect first
+  if (self.db && self.db.topology && !self.db.topology.isDestroyed()) {
     doExecute();
   } else {
+    if (self.db) {
+      self.disconnect();
+      self.db = null;
+    }
     self.connect(function(err, db) {
       if (err) {
         debug('Connection not established - MongoDB: model=%s command=%s -- error=%s', model, command, err);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -76,22 +76,22 @@ describe('lazyConnect', function() {
       value: { type: String },
     });
 
+    ds.connector.should.not.have.property('db');
+
     ds.connector.execute('TestLazy', 'insert', { 'value': 'test value' }, function(err, success) {
-      if (err) {
-        done(err);
-      } else {
-        var id = success.insertedIds[0];
-
-        ds.connector.disconnect();
-
-        ds.connector.execute('TestLazy', 'findOne', { _id: id }, function(err, data) {
-          if (err) {
-            done(err);
-          } else {
-            done();
-          }
-        });
-      }
+      if (err) done(err);
+      var id = success.insertedIds[0];
+      ds.connector.should.have.property('db');
+      ds.connector.db.should.have.property('topology');
+      ds.connector.db.topology.should.have.property('isDestroyed');
+      ds.connector.db.topology.isDestroyed().should.be.false;
+      ds.connector.disconnect();
+      ds.connector.db.topology.isDestroyed().should.be.true;
+      ds.connector.execute('TestLazy', 'findOne', { _id: id }, function(err, data) {
+        if (err) done(err);
+        ds.connector.db.topology.isDestroyed().should.be.false;
+        done();
+      });
     });
   });
 });

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -64,6 +64,36 @@ describe('lazyConnect', function() {
       }
     });
   });
+
+  it('should reconnect on execute when disconnected (lazyConnect = true)', function(done) {
+    var ds = getDataSource({
+      host: '127.0.0.1',
+      port: config.port,
+      lazyConnect: true,
+    });
+
+    ds.define('TestLazy', {
+      value: { type: String },
+    });
+
+    ds.connector.execute('TestLazy', 'insert', { 'value': 'test value' }, function(err, success) {
+      if (err) {
+        done(err);
+      } else {
+        var id = success.insertedIds[0];
+
+        ds.connector.disconnect();
+
+        ds.connector.execute('TestLazy', 'findOne', { _id: id }, function(err, data) {
+          if (err) {
+            done(err);
+          } else {
+            done();
+          }
+        });
+      }
+    });
+  });
 });
 
 describe('mongodb connector', function() {


### PR DESCRIPTION
### Description
When the database server is unreachable beyond the configured retry limit the client will become disconnected and unusable even if the server becomes available again. We should attempt to reconnect the client on the next call to execute in order for the client application to survive a loss of connection to the server beyond the configured retry limit. This is similar to the lazy connect feature where the client app is up and running before the database is available and the call to execute initiates an attempt to connect.

#### Related issues
#630