### PR TITLE
test: use mongodb-3.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,10 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - mongodb-3.2-precise
     packages:
       - g++-4.8
+      - mongodb-org-server
+      - mongodb-org-shell
 services:
   - mongodb
-before_script:
-  - mongo mydb_test --eval 'db.addUser("travis", "test");'


### PR DESCRIPTION
The default version is 2.6, which is simply too old for some of the
features used in the tests.