### PR TITLE
Invoke buildSort directly

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1038,41 +1038,10 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
     if (err) {
       return callback(err);
     }
-    var order = {};
 
     // don't apply sorting if dealing with a geo query
     if (!hasNearFilter(filter.where)) {
-      if (!filter.order) {
-        var idNames = self.idNames(model);
-        if (idNames && idNames.length) {
-          filter.order = idNames;
-        }
-      }
-      if (filter.order) {
-        var keys = filter.order;
-        if (typeof keys === 'string') {
-          keys = keys.split(',');
-        }
-        for (var index = 0, len = keys.length; index < len; index++) {
-          var m = keys[index].match(/\s+(A|DE)SC$/);
-          var key = keys[index];
-          key = key.replace(/\s+(A|DE)SC$/, '').trim();
-          if (key === idName) {
-            key = '_id';
-          } else {
-            key = self.getDatabaseColumnName(model, key);
-          }
-
-          if (m && m[1] === 'DE') {
-            order[key] = -1;
-          } else {
-            order[key] = 1;
-          }
-        }
-      } else {
-        // order by _id by default
-        order = { _id: 1 };
-      }
+      var order = self.buildSort(model, filter.order);
       cursor.sort(order);
     }
 


### PR DESCRIPTION
### Description
Allow use of buildSort function directly in `MongoDB.prototype.all` rather than in line sorting.

connect to https://github.com/strongloop/loopback-connector-mongodb/issues/300