### PR TITLE
Allow regexp on like/nlike operator

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -736,9 +736,17 @@ MongoDB.prototype.buildWhere = function(model, where) {
           }),
         };
       } else if (spec === 'like') {
-        query[k] = { $regex: new RegExp(cond, options) };
+        if (cond instanceof RegExp) {
+          query[k] = { $regex: cond };
+        } else {
+          query[k] = { $regex: new RegExp(cond, options) };
+        }
       } else if (spec === 'nlike') {
-        query[k] = { $not: new RegExp(cond, options) };
+        if (cond instanceof RegExp) {
+          query[k] = { $not: cond };
+        } else {
+          query[k] = { $not: new RegExp(cond, options) };
+        }
       } else if (spec === 'neq') {
         query[k] = { $ne: cond };
       } else if (spec === 'regexp') {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2367,6 +2367,169 @@ describe('mongodb connector', function() {
     });
   });
 
+  context('like and nlike operator', function() {
+    before(function deleteExistingTestFixtures(done) {
+      Post.destroyAll(done);
+    });
+    beforeEach(function createTestFixtures(done) {
+      Post.create([
+        { title: 'a', content: 'AAA' },
+        { title: 'b', content: 'BBB' },
+      ], done);
+    });
+    after(function deleteTestFixtures(done) {
+      Post.destroyAll(done);
+    });
+
+    context('like operator', function() {
+      context('with regex strings', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: '^A' }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: '^a', options: 'i' }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+      });
+
+      context('with regex literals', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: /^A/ }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: /^a/i }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+      });
+
+      context('with regex object', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: new RegExp(/^A/) }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { like: new RegExp(/^a/i) }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('AAA');
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    context('nlike operator', function() {
+      context('with regex strings', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: '^A' }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: '^a', options: 'i' }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+      });
+
+      context('with regex literals', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: /^A/ }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: /^a/i }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+      });
+
+      context('with regex object', function() {
+        context('using no flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: new RegExp(/^A/) }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+
+        context('using flags', function() {
+          it('should work', function(done) {
+            Post.find({ where: { content: { nlike: new RegExp(/^a/i) }}}, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.equal(1);
+              posts[0].content.should.equal('BBB');
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
   after(function(done) {
     User.destroyAll(function() {
       Post.destroyAll(function() {


### PR DESCRIPTION
### Description
Allow the user to specify the regexp on a `like` or `nlike` operator in different forms other than just string and then letting our mongodb ORM creating the RegExp object. This feature shall allow the user to filter using `like` and `nlike` operator using different forms of regexp:
- regexp as a string (i.e `'^H.'`)
- regexp as a literal (i.e `/^H/`)
- regexp as an object (i.e `new RegExp(/^H/)`)

connect to https://github.com/strongloop/loopback-connector-mongodb/issues/151