### PR TITLE
Remove the hard-coded writeConcern

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -426,7 +426,7 @@ MongoDB.prototype.save = function(model, data, options, callback) {
 
   data = self.toDatabase(model, data);
 
-  this.execute(model, 'save', data, { w: 1 }, function(err, result) {
+  this.execute(model, 'save', data, {}, function(err, result) {
     if (!err) {
       self.setIdValue(model, data, idValue);
       idName !== '_id' && delete data._id;


### PR DESCRIPTION
{w: 1} is not always valid.
See https://docs.mongodb.com/manual/reference/write-concern/#write-concern

### Description

When performing a PUT operation from Loopback app to compose for mongo instance, it throws exception:
```
{"error": {
   "name": "MongoError",
   "status": 500,
   "message": "w: 'majority' is the only valid write concern when writing to config server replica sets, got: { w: 1, wtimeout: 0 }",
   "ok": 0,
   "errmsg": "w: 'majority' is the only valid write concern when writing to config server replica sets, got: { w: 1, wtimeout: 0 }",
   "code": 2
}}
```
#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
