### PR TITLE
Fix converting field filter names to column names on MongoDB.prototype.all

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1013,6 +1013,12 @@ MongoDB.prototype.fromDatabaseToPropertyNames = function(model, data) {
   return this.convertColumnNames(model, data, 'property');
 };
 
+/**
+ * Transform the fields as defined in the Loopback query to the column names used in the database.
+ * @param model The Loopback model.
+ * @param data The array containing the fields.
+ * @returns {*} A new array containing the transformed fields.
+ */
 MongoDB.prototype.fromFieldFilterToDatabaseNames = function(model, data) {
   if (!Array.isArray(data)) {
     return data; // skip

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1013,6 +1013,31 @@ MongoDB.prototype.fromDatabaseToPropertyNames = function(model, data) {
   return this.convertColumnNames(model, data, 'property');
 };
 
+MongoDB.prototype.fromFieldFilterToDatabaseNames = function(model, data) {
+    if (!Array.isArray(data)) {
+        return data; // skip
+    }
+
+    if (typeof model === 'string') {
+        model = this._models[model];
+    }
+
+    if (typeof model !== 'object') {
+        return data; // unknown model type?
+    }
+
+    if (typeof model.properties !== 'object') {
+        return data; // missing model properties?
+    }
+
+    var databaseNameData = [];
+    for (var i = 0; i < data.length; i++) {
+        databaseNameData.push(this.getDatabaseColumnName(model, data[i]));
+    }
+
+    return databaseNameData;
+};
+
 /**
  * Find matching model instances by the filter
  *
@@ -1034,7 +1059,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
   var fields = filter.fields;
 
   // Convert custom column names
-  fields = self.fromPropertyToDatabaseNames(model, fields);
+  fields = self.fromFieldFilterToDatabaseNames(model, fields);
 
   if (fields) {
     this.execute(model, 'find', query, fields, processResponse);

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1014,28 +1014,28 @@ MongoDB.prototype.fromDatabaseToPropertyNames = function(model, data) {
 };
 
 MongoDB.prototype.fromFieldFilterToDatabaseNames = function(model, data) {
-    if (!Array.isArray(data)) {
-        return data; // skip
-    }
+  if (!Array.isArray(data)) {
+    return data; // skip
+  }
 
-    if (typeof model === 'string') {
-        model = this._models[model];
-    }
+  if (typeof model === 'string') {
+    model = this._models[model];
+  }
 
-    if (typeof model !== 'object') {
-        return data; // unknown model type?
-    }
+  if (typeof model !== 'object') {
+    return data; // unknown model type?
+  }
 
-    if (typeof model.properties !== 'object') {
-        return data; // missing model properties?
-    }
+  if (typeof model.properties !== 'object') {
+    return data; // missing model properties?
+  }
 
-    var databaseNameData = [];
-    for (var i = 0; i < data.length; i++) {
-        databaseNameData.push(this.getDatabaseColumnName(model, data[i]));
-    }
+  var databaseNameData = [];
+  for (var i = 0; i < data.length; i++) {
+    databaseNameData.push(this.getDatabaseColumnName(model, data[i]));
+  }
 
-    return databaseNameData;
+  return databaseNameData;
 };
 
 /**

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2542,3 +2542,57 @@ describe('mongodb connector', function() {
     });
   });
 });
+
+describe('fromFieldFilterToDatabaseNames', function() {
+  var ds = getDataSource();
+  var Foo = ds.define('Foo', {
+    name: {
+      type: 'string',
+      description: 'The name of the foo.',
+    },
+    foo: {
+      type: 'string',
+      mongodb: {
+        columnName: 'f',
+      },
+    },
+    baz: {
+      type: 'string',
+      mongodb: {
+        columnName: 'bz',
+      },
+    },
+    bar: {
+      type: 'string',
+      mongodb: {
+        columnName: 'br',
+      },
+    },
+  });
+  it('returns data as-is when Object', function() {
+    var data = { foo: 'foo', baz: 'baz' };
+    var result = ds.connector.fromFieldFilterToDatabaseNames('Foo', data);
+    result.should.equal(data); // Should be the same ref
+  });
+  it('returns data as-is when String', function() {
+    var data = 'test';
+    var result = ds.connector.fromFieldFilterToDatabaseNames('Foo', data);
+    result.should.equal(data); // Should be the same ref
+  });
+  it('returns transformed data when Array', function() {
+    var data = ['foo', 'baz'];
+    var result = ds.connector.fromFieldFilterToDatabaseNames('Foo', data);
+    result.should.be.instanceOf(Array); // Should be an Array
+    result.should.have.lengthOf(2); // Should have length of 2
+    result.should.containDeep(['f', 'bz']); // Should contain transformed fields
+  });
+  it('returns transformed and clean data when Array with properties', function() {
+    var data = ['foo', 'baz'];
+    data.foo = 'test';
+    data.baz = 'test';
+    var result = ds.connector.fromFieldFilterToDatabaseNames('Foo', data);
+    result.should.be.instanceOf(Array); // Should be an Array
+    result.should.have.lengthOf(2); // Should have length of 2
+    result.should.containDeep(['f', 'bz']); // Should contain transformed fields
+  });
+});


### PR DESCRIPTION
### Description

https://github.com/strongloop/loopback-connector-mongodb/pull/189
Introduced a feature to allow specifying columnNames just like in the relational database connectors. However when using the columnNames any fields filter used in the query doesn't get rewritten correctly. This pull request fixes that.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
