### PR TITLE
Switch to bson.ObjectID

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -6,6 +6,7 @@
 /*!
  * Module dependencies
  */
+var bson = require('bson');
 var g = require('strong-globalize')();
 var mongodb = require('mongodb');
 var util = require('util');
@@ -31,7 +32,7 @@ function ObjectID(id) {
     // hex string. For LoopBack, we only allow 24-byte hex string, but 12-byte
     // string such as 'line-by-line' should be kept as string
     if (/^[0-9a-fA-F]{24}$/.test(id)) {
-      return new mongodb.ObjectID(id);
+      return bson.ObjectID(id);
     } else {
       return id;
     }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.0.0",
+    "bson": "^1.0.4",
     "debug": "^2.1.1",
     "loopback-connector": "^4.0.0",
     "mongodb": "^2.1.21",


### PR DESCRIPTION
### Description
Switch to the bson.ObjectID for the ObjectID type validator/creator function.
This change would be made in step with the related issue below, to ensure that they're using the same type definition.

The alternative to this would be to import mongodb as a devDep in the juggler (which would be silly when we have bson).

#### Related issues
connected to https://github.com/strongloop/loopback-datasource-juggler/pull/1526

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
