### PR TITLE
Alias find as findById

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -501,6 +501,9 @@ MongoDB.prototype.find = function find(model, id, options, callback) {
   });
 };
 
+Connector.defineAliases(MongoDB.prototype, 'find',
+'findById');
+
 /**
  * Parses the data input for update operations and returns the
  * sanitised version of the object.

--- a/test/connector-functions.test.js
+++ b/test/connector-functions.test.js
@@ -1,0 +1,31 @@
+// Copyright IBM Corp. 2013,2016. All Rights Reserved.
+// Node module: loopback-connector-mongodb
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+// This test written in mocha+should.js
+var should = require('./init.js');
+
+describe('connector function - findById', function() {
+  var db, TestAlias, sampleId;
+  before(function(done) {
+    db = getDataSource();
+    TestAlias = db.define('TestAlias', { foo: { type: String }});
+    db.automigrate(function(err) {
+      if (err) return done(err);
+      TestAlias.create({ foo: 'foo' }, function(err, t) {
+        if (err) return done(err);
+        sampleId = t.id;
+        done();
+      });
+    });
+  });
+
+  it('find is aliased as findById', function(done) {
+    db.connector.findById('TestAlias', sampleId, {}, function(err, r) {
+      if (err) return done(err);
+      r.foo.should.equal('foo');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
### Description

Some connectors call the function that finds instance by id as `find`only but some call it as `findById` only, I am unifying them as `findById` across all connectors.

#### Related issues

https://github.com/strongloop/loopback-datasource-juggler/pull/1459


### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
