### PR TITLE
fix: allow db name to be parsed from url

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -9,6 +9,7 @@
 var bson = require('bson');
 var g = require('strong-globalize')();
 var mongodb = require('mongodb');
+var urlParser = require('mongodb/lib/url_parser');
 var util = require('util');
 var async = require('async');
 var Connector = require('loopback-connector').Connector;
@@ -215,20 +216,24 @@ MongoDB.prototype.connect = function(callback) {
         validOptions[option] = self.settings[option];
       }
     });
-    debug('Valid options: %j' + validOptions);
+    debug('Valid options: %j', validOptions);
     new mongodb.MongoClient(self.settings.url, validOptions).connect(function(err, client) {
       if (!err) {
         if (self.debug) {
           debug('MongoDB connection is established: ' + self.settings.url);
         }
         self.client = client;
-        self.db = client.db(self.settings.database);
+        // The database name might be in the url
+        return urlParser(self.settings.url, self.settings, function(err, url) {
+          self.db = client.db(self.settings.database || url.dbName, url.db_options || self.settings);
+          callback && callback(err, self.db);
+        });
       } else {
         if (self.debug || !callback) {
           g.error('{{MongoDB}} connection is failed: %s %s', self.settings.url, err);
         }
+        callback && callback(err, self.db);
       }
-      callback && callback(err, self.db);
     });
   }
 };

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -250,7 +250,20 @@ describe('mongodb connector', function() {
       var configWithInvalidOption = config;
       configWithInvalidOption.invalidOption = 'invalid';
       var ds = getDataSource(configWithInvalidOption);
-      ds.ping(done);
+      ds.ping(function(err) {
+        if (err) return done(err);
+        ds.disconnect(done);
+      });
+    });
+
+    it('accepts database from the url', function(done) {
+      var cfg = JSON.parse(JSON.stringify(config));
+      delete cfg.database;
+      var ds = getDataSource(cfg);
+      ds.ping(function(err) {
+        if (err) return done(err);
+        ds.disconnect(done);
+      });
     });
   });
 


### PR DESCRIPTION
See https://github.com/strongloop/loopback-connector-mongodb/issues/412

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #412

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
