### PR TITLE
chore: Update bson version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^2.6.0",
-    "bson": "^1.0.4",
+    "bson": "^1.0.6",
     "debug": "^3.1.0",
     "loopback-connector": "^4.0.0",
     "mongodb": "^3.0.1",


### PR DESCRIPTION
Update bson version in package.json to 1.0.5 or higher
to address [npm:bson:20180225](https://snyk.io/vuln/npm:bson:20180225).  

There was an attempt to use bson 2.x, but there seems to be breaking changes. 