### PR TITLE
Convert data to database format when doing replaceOrCreate

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -685,14 +685,18 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(model, data, options,
  * @param {Function} [cb] The callback function
  */
 MongoDB.prototype.replaceOrCreate = function(model, data, options, cb) {
-  if (this.debug) debug('replaceOrCreate', model, data);
+  var self = this;
+  if (self.debug) debug('replaceOrCreate', model, data);
 
-  var id = this.getIdValue(model, data);
-  var oid = this.coerceId(model, id);
-  var idName = this.idName(model);
+  var id = self.getIdValue(model, data);
+  var oid = self.coerceId(model, id);
+  var idName = self.idName(model);
   data._id = data[idName];
   delete data[idName];
-  this.replaceWithOptions(model, oid, data, { upsert: true }, cb);
+
+  data = self.toDatabase(model, data);
+
+  self.replaceWithOptions(model, oid, data, { upsert: true }, cb);
 };
 
 /**


### PR DESCRIPTION
### Description

Convert data to mongodb format when doing replaceOrCreate (PUT), especially when working with GeoPoint.

```
Unhandled error for request PUT /v1/FuelStations: MongoError: Can't extract geo keys: { _id: "3316", permit_id: "PL/1982/EXP/ES/2015", name: "Combustibles Minotauro, S.A.  de C.V.", address: "Avenida Valdepeñas No. 1920", location: { lat: 20.74094, lng: -103.3991 } }  can't project geometry into spherical CRS: { lat: 20.74094, lng: -103.3991 }
    at Function.MongoError.create (/Users/tuxity/perso/fuelstations-api/node_modules/mongodb-core/lib/error.js:45:10)
    at toError (/Users/tuxity/perso/fuelstations-api/node_modules/mongodb/lib/utils.js:149:22)
    at /Users/tuxity/perso/fuelstations-api/node_modules/mongodb/lib/collection.js:1033:39
    at /Users/tuxity/perso/fuelstations-api/node_modules/mongodb-core/lib/connection/pool.js:541:18
    at process._tickCallback (internal/process/next_tick.js:112:11)
```

#### Related issues

https://github.com/strongloop/loopback/issues/3648
