### PR TITLE
Add settings disableDefaultSort for find method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ of type `GeoPoint`. This allows for indexed ```near``` queries.  Default is `fal
   - Default is `false`.
   - If set to `true`, the database instance will not be attached to the datasource and the connection is deferred.
   - It will try to establish the connection automatically once users hit the endpoint. If the mongodb server is offline, the app will start, however, the endpoints will not work.
-
+- **disableDefaultSort**: Set to `true` to disable the default sorting
+  behavior on `id` column, this will help performance using indexed
+columns available in mongodb.
 ### Setting the url property in datasource.json
 
 You can set the `url` property to a connection URL in `datasources.json` to override individual connection parameters such as `host`, `user`, and `password`.  

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -942,13 +942,15 @@ MongoDB.prototype.buildSort = function(model, order, options) {
 
   var modelClass = this._models[model];
 
-  var disableDefaultSort = this.settings.disableDefaultSort;
+  var disableDefaultSort = false;
+  if (this.settings.hasOwnProperty('disableDefaultSort')) {
+    disableDefaultSort = this.settings.disableDefaultSort;
+  }
+  if (modelClass.settings.hasOwnProperty('disableDefaultSort')) {
+    disableDefaultSort = modelClass.settings.disableDefaultSort;
+  }
   if (options && options.hasOwnProperty('disableDefaultSort')) {
-    disableDefaultSort = options.disableDefaultSort === true;
-  } else if (disableDefaultSort !== false && modelClass.settings.hasOwnProperty('disableDefaultSort')) {
-    disableDefaultSort = modelClass.settings.disableDefaultSort === true;
-  } else if (disableDefaultSort === true) {
-    disableDefaultSort = true;
+    disableDefaultSort = options.disableDefaultSort;
   }
 
   if (!order && !disableDefaultSort) {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -936,10 +936,22 @@ MongoDB.prototype.buildWhere = function(model, where) {
   return query;
 };
 
-MongoDB.prototype.buildSort = function(model, order) {
+MongoDB.prototype.buildSort = function(model, order, options) {
   var sort = {};
   var idName = this.idName(model);
-  if (!order) {
+
+  var modelClass = this._models[model];
+
+  var disableDefaultSort = this.settings.disableDefaultSort;
+  if (options && options.hasOwnProperty('disableDefaultSort')) {
+    disableDefaultSort = options.disableDefaultSort === true;
+  } else if (disableDefaultSort !== false && modelClass.settings.hasOwnProperty('disableDefaultSort')) {
+    disableDefaultSort = modelClass.settings.disableDefaultSort === true;
+  } else if (disableDefaultSort === true) {
+    disableDefaultSort = true;
+  }
+
+  if (!order && !disableDefaultSort) {
     var idNames = this.idNames(model);
     if (idNames && idNames.length) {
       order = idNames;
@@ -966,7 +978,7 @@ MongoDB.prototype.buildSort = function(model, order) {
         sort[key] = 1;
       }
     }
-  } else {
+  } else if (!disableDefaultSort) {
     // order by _id by default
     sort = {_id: 1};
   }
@@ -1224,7 +1236,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
 
     // don't apply sorting if dealing with a geo query
     if (!hasNearFilter(filter.where)) {
-      var order = self.buildSort(model, filter.order);
+      var order = self.buildSort(model, filter.order, options);
       cursor.sort(order);
     }
 

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2490,6 +2490,34 @@ describe('mongodb connector', function() {
     });
   });
 
+  it('find should not order by id if the order is not set for the query filter and settings.disableDefaultSort is true',
+    function(done) {
+      PostWithStringId.settings.disableDefaultSort = true;
+
+      PostWithStringId.create({ id: '2', title: 'c', content: 'CCC' }, function(err, post) {
+        PostWithStringId.create({ id: '1', title: 'd', content: 'DDD' }, function(err, post) {
+          PostWithStringId.find({}, function(err, posts) {
+            should.not.exist(err);
+            posts.length.should.be.equal(2);
+            posts[0].id.should.be.equal('2');
+
+            PostWithStringId.find({ limit: 1, offset: 0 }, function(err, posts) {
+              should.not.exist(err);
+              posts.length.should.be.equal(1);
+              posts[0].id.should.be.equal('2');
+
+              PostWithStringId.find({ limit: 1, offset: 1 }, function(err, posts) {
+                should.not.exist(err);
+                posts.length.should.be.equal(1);
+                posts[0].id.should.be.equal('1');
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
   it('should report error on duplicate keys', function(done) {
     Post.create({title: 'd', content: 'DDD'}, function(err, post) {
       Post.create({id: post.id, title: 'd', content: 'DDD'}, function(

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -26,7 +26,8 @@ var Superhero,
   Category,
   UserWithRenamedColumns,
   PostWithStringIdAndRenamedColumns,
-  Employee;
+  Employee,
+  PostWithDisableDefaultSort;
 
 describe('lazyConnect', function() {
   it('should skip connect phase (lazyConnect = true)', function(done) {
@@ -273,6 +274,18 @@ describe('mongodb connector', function() {
       }
     );
 
+    PostWithDisableDefaultSort = db.define(
+      'PostWithDisableDefaultSort',
+      {
+        id: {type: String, id: true},
+        title: {type: String, length: 255, index: true},
+        content: {type: String},
+      },
+      {
+        disableDefaultSort: true,
+      }
+    );
+
     User.hasMany(Post);
     Post.belongsTo(User);
   });
@@ -285,7 +298,9 @@ describe('mongodb connector', function() {
           PostWithNumberId.destroyAll(function() {
             PostWithNumberUnderscoreId.destroyAll(function() {
               PostWithStringId.destroyAll(function() {
-                done();
+                PostWithDisableDefaultSort.destroyAll(function() {
+                  done();
+                });
               });
             });
           });
@@ -2492,21 +2507,19 @@ describe('mongodb connector', function() {
 
   it('find should not order by id if the order is not set for the query filter and settings.disableDefaultSort is true',
     function(done) {
-      PostWithStringId.settings.disableDefaultSort = true;
-
-      PostWithStringId.create({ id: '2', title: 'c', content: 'CCC' }, function(err, post) {
-        PostWithStringId.create({ id: '1', title: 'd', content: 'DDD' }, function(err, post) {
-          PostWithStringId.find({}, function(err, posts) {
+      PostWithDisableDefaultSort.create({id: '2', title: 'c', content: 'CCC'}, function(err, post) {
+        PostWithDisableDefaultSort.create({id: '1', title: 'd', content: 'DDD'}, function(err, post) {
+          PostWithDisableDefaultSort.find({}, function(err, posts) {
             should.not.exist(err);
             posts.length.should.be.equal(2);
             posts[0].id.should.be.equal('2');
 
-            PostWithStringId.find({ limit: 1, offset: 0 }, function(err, posts) {
+            PostWithDisableDefaultSort.find({limit: 1, offset: 0}, function(err, posts) {
               should.not.exist(err);
               posts.length.should.be.equal(1);
               posts[0].id.should.be.equal('2');
 
-              PostWithStringId.find({ limit: 1, offset: 1 }, function(err, posts) {
+              PostWithDisableDefaultSort.find({limit: 1, offset: 1}, function(err, posts) {
                 should.not.exist(err);
                 posts.length.should.be.equal(1);
                 posts[0].id.should.be.equal('1');


### PR DESCRIPTION
### Description
This PR will add a settings `disableDefaultSort` for disabling the default sort by `id` on all `find` queries without a `order` parameter.
I implemented the settings like `allowExtendedOperators`.
It's disabled by default so no breaking change for the find behavior.

#### Related issues

- connect to #55 

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

### To review

* I change the prototype of `buildSort` function to add `options` from `find`, this may have a impact ?
* `options` can not be pass from `findOrCreate` method because the prototype doesn't have `options` parameter
* My tests do not cover all the ways for setting `disableDefaultSort`, is it relevant to add them like for `allowExtendedOperators` ?
* You maybe want an other name for `disableDefaultSort` ?