### PR TITLE
Fix missing '_id' when selected in filter.fields

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1315,7 +1315,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
     }
 
     var shouldSetIdValue = idIncluded(fields, idName);
-    var deleteMongoId = fields || idName !== '_id';
+    var deleteMongoId = !shouldSetIdValue || idName !== '_id';
 
     cursor.toArray(function(err, data) {
       if (self.debug) {

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -628,6 +628,25 @@ describe('mongodb connector', function() {
           should.not.exist(post._id);
 
           done();
+        });
+    });
+  });
+
+  it('all return should honor filter.fields with `_id` selected', function(done) {
+    var post = new PostWithObjectId({title: 'a', content: 'AAA'});
+    post.save(function(err, post) {
+      PostWithObjectId.all(
+        {fields: ['_id', 'content'], where: {title: 'a'}},
+        function(err, posts) {
+          should.not.exist(err);
+          if (err) return done(err);
+          posts.should.have.lengthOf(1);
+          post = posts[0];
+          should.not.exist(post.title);
+          post.should.have.property('content', 'AAA');
+          post._id.should.be.an.instanceOf(db.ObjectID);
+
+          done();
         }
       );
     });


### PR DESCRIPTION
### Description
The field `_id` was always getting removed from the query results when filter.fields was present. This is a problem if the model defines `_id` as the id property and you want to include it in the results. 

Moreover, the variable `deleteMongoId` was erroneously being assigned the *value* of `fields`, and not a boolean determining the *presence* of `fields` (lib/mongodb.js:1137).

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #440

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
