### PR TITLE
add `useNewUrlParser` on validOptionNames

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1322,7 +1322,7 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
     debug('count', model, where);
   }
   where = self.buildWhere(model, where);
-  this.execute(model, 'count', where, function(err, count) {
+  this.execute(model, 'countDocuments', where, function(err, count) {
     if (self.debug) {
       debug('count.callback', model, err, count);
     }

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -221,6 +221,7 @@ MongoDB.prototype.connect = function(callback) {
       'numberOfRetries',
       'auto_reconnect',
       'minSize',
+      'useNewUrlParser',
       // Ignored options
       'native_parser',
       // Legacy options


### PR DESCRIPTION
### Description
This pr will add `useNewUrlParser` option on `validOptionNames` at `lib/mongodb.js` to remove deprecation warning 

`DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.`

when using mongo url to connect to database.

#### Related issues
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #449

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
