### PR TITLE
fix: sanitize query by default

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -840,19 +840,22 @@ function idIncluded(fields, idName) {
   return true;
 }
 
-MongoDB.prototype.buildWhere = function(model, where) {
+MongoDB.prototype.buildWhere = function(model, where, options) {
   var self = this;
   var query = {};
   if (where === null || typeof where !== 'object') {
     return query;
   }
+
+  where = sanitizeFilter(where, options);
+
   var idName = self.idName(model);
   Object.keys(where).forEach(function(k) {
     var cond = where[k];
     if (k === 'and' || k === 'or' || k === 'nor') {
       if (Array.isArray(cond)) {
         cond = cond.map(function(c) {
-          return self.buildWhere(model, c);
+          return self.buildWhere(model, c, options);
         });
       }
       query['$' + k] = cond;
@@ -961,6 +964,7 @@ MongoDB.prototype.buildSort = function(model, order, options) {
     }
   }
   if (order) {
+    order = sanitizeFilter(order, options);
     var keys = order;
     if (typeof keys === 'string') {
       keys = keys.split(',');
@@ -1217,7 +1221,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
   var idName = self.idName(model);
   var query = {};
   if (filter.where) {
-    query = self.buildWhere(model, filter.where);
+    query = self.buildWhere(model, filter.where, options);
   }
   var fields = filter.fields;
 
@@ -1308,7 +1312,8 @@ MongoDB.prototype.destroyAll = function destroyAll(
     callback = where;
     where = undefined;
   }
-  where = self.buildWhere(model, where);
+  where = self.buildWhere(model, where, options);
+
   this.execute(model, 'remove', where || {}, function(err, info) {
     if (err) return callback && callback(err);
 
@@ -1335,7 +1340,7 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
   if (self.debug) {
     debug('count', model, where);
   }
-  where = self.buildWhere(model, where);
+  where = self.buildWhere(model, where, options);
   this.execute(model, 'countDocuments', where, function(err, count) {
     if (self.debug) {
       debug('count.callback', model, err, count);
@@ -1506,9 +1511,9 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
   }
   var idName = this.idName(model);
 
-  where = self.buildWhere(model, where);
-  delete data[idName];
+  where = self.buildWhere(model, where, options);
 
+  delete data[idName];
   data = self.toDatabase(model, data);
 
   // Check for other operators and sanitize the data obj
@@ -1798,6 +1803,23 @@ MongoDB.prototype.isObjectIDProperty = function(model, prop, value) {
   }
 };
 
+function sanitizeFilter(filter, options) {
+  options = Object.assign({}, options);
+  if (options && options.disableSanitization) return filter;
+  if (!filter || typeof filter !== 'object') return filter;
+
+  for (const key in filter) {
+    if (key === '$where' || key === 'mapReduce') {
+      debug(`sanitizeFilter: deleting ${key}`);
+      delete filter[key];
+    }
+  }
+
+  return filter;
+}
+
+exports.sanitizeFilter = sanitizeFilter;
+
 /**
  * Find a matching model instances by the filter or create a new instance
  *
@@ -1808,11 +1830,13 @@ MongoDB.prototype.isObjectIDProperty = function(model, prop, value) {
  * @param {Object} filter The filter
  * @param {Function} [callback] The callback function
  */
-function optimizedFindOrCreate(model, filter, data, callback) {
+function optimizedFindOrCreate(model, filter, data, options, callback) {
   var self = this;
   if (self.debug) {
     debug('findOrCreate', model, filter, data);
   }
+
+  if (!callback) callback = options;
 
   var idValue = self.getIdValue(model, data);
   var idName = self.idName(model);
@@ -1836,10 +1860,10 @@ function optimizedFindOrCreate(model, filter, data, callback) {
       id = self.coerceId(model, id);
       filter.where._id = id;
     }
-    query = self.buildWhere(model, filter.where);
+    query = self.buildWhere(model, filter.where, options);
   }
 
-  var sort = self.buildSort(model, filter.order);
+  var sort = self.buildSort(model, filter.order, options);
 
   this.collection(model).findOneAndUpdate(
     query,


### PR DESCRIPTION
### Description

This PR adds a sanitization step to the `buildWhere` and `buildSort` function using the new `sanitizeFilter` function. 

This function accepts an option in an options object `disableSanitization` - which can be any truthy value to disable sanitization (filter passed in is returned as-is)

As per https://docs.mongodb.com/manual/core/server-side-javascript/ only `$where` and `mapReduce` properties can execute JavaScript on the Mongo Driver so `sanitizeFilter` removes those properties if present at the top level of the query object.

#### Related issues

fixes https://github.com/strongloop/loopback-connector-mongodb/issues/403

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
