### PR TITLE
Add support to protocol to be 'monogodb+srv'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ b benchmark benchmarks:
 
 .PHONY: l ld leak leak-detection
 l ld leak leak-detection:
+	npm i @airbnb/node-memwatch --no-save || npm i memwatch-next --no-save
 	@ITERATIONS=$(ITERATIONS) $(TESTER) leak-detection \
 		--recursive \
 		--reporter spec \

--- a/leak-detection/leak-detector.test.js
+++ b/leak-detection/leak-detector.test.js
@@ -5,7 +5,13 @@
 
 'use strict';
 
-var memwatch = require('memwatch-next');
+var memwatch;
+
+try {
+  memwatch = require('@airbnb/node-memwatch');
+} catch (e) {
+  memwatch = require('memwatch-next');
+}
 var sinon = require('sinon');
 
 describe('leak detector', function() {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -49,13 +49,17 @@ exports.generateMongoDBURL = generateMongoDBURL;
  * Generate the mongodb URL from the options
  */
 function generateMongoDBURL(options) {
+  // See https://docs.mongodb.com/manual/reference/connection-string/#dns-seedlist-connection-format
+  // It can be `mongodb+srv` now.
+  options.protocol = options.protocol || 'mongodb';
   options.hostname = options.hostname || options.host || '127.0.0.1';
   options.port = options.port || 27017;
   options.database = options.database || options.db || 'test';
   var username = options.username || options.user;
   if (username && options.password) {
     return (
-      'mongodb://' +
+      options.protocol +
+      '://' +
       username +
       ':' +
       options.password +
@@ -68,7 +72,8 @@ function generateMongoDBURL(options) {
     );
   } else {
     return (
-      'mongodb://' +
+      options.protocol +
+      '://' +
       options.hostname +
       ':' +
       options.port +

--- a/package.json
+++ b/package.json
@@ -26,23 +26,23 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.0",
+    "async": "^2.6.1",
     "bson": "^1.0.6",
     "debug": "^3.1.0",
     "loopback-connector": "^4.5.0",
-    "mongodb": "^3.0.1",
+    "mongodb": "^3.1.4",
     "strong-globalize": "^4.1.1"
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "bluebird": "^3.5.1",
+    "bluebird": "^3.5.2",
     "eslint": "^5.1.0",
     "eslint-config-loopback": "^10.0.0",
-    "loopback-datasource-juggler": "^3.0.0",
+    "loopback-datasource-juggler": "^3.23.0",
     "memwatch-next": "^0.3.0",
     "mocha": "^5.2.0",
     "rc": "^1.2.8",
-    "semver": "^5.5.0",
+    "semver": "^5.5.1",
     "should": "^13.2.1",
     "sinon": "^6.1.3"
   }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint": "^5.1.0",
     "eslint-config-loopback": "^10.0.0",
     "loopback-datasource-juggler": "^3.23.0",
-    "memwatch-next": "^0.3.0",
     "mocha": "^5.2.0",
     "rc": "^1.2.8",
     "semver": "^5.5.1",


### PR DESCRIPTION
See https://docs.mongodb.com/manual/reference/connection-string/

### Description

We don't have a way to specify `mongodb+srv://`. This PR makes it configurable.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
