### PR TITLE
Convert projection fields option to object

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -127,6 +127,36 @@ const COMMAND_MAPPINGS = {
   estimatedDocumentCount: 'count',
 };
 
+/**
+ * Helper function to be used in {@ fieldsArrayToObj} in order for V8 to avoid re-creating a new
+ * function every time {@ fieldsArrayToObj} is called
+ *
+ * @see fieldsArrayToObj
+ * @param {object} result
+ * @param {string} field
+ * @returns {object}
+ */
+function arrayToObjectReducer(result, field) {
+  result[field] = 1;
+  return result;
+}
+
+exports.fieldsArrayToObj = fieldsArrayToObj;
+
+/**
+ * Helper function to accept an array representation of fields projection and return the mongo
+ * required object notation
+ *
+ * @param {string[]} fieldsArray
+ * @returns {Object}
+ */
+function fieldsArrayToObj(fieldsArray) {
+  if (!Array.isArray(fieldsArray)) return fieldsArray; // fail safe check in case non array object created
+  return fieldsArray.length ?
+    fieldsArray.reduce(arrayToObjectReducer, {}) :
+    {_id: 1};
+}
+
 exports.MongoDB = MongoDB;
 
 /**
@@ -1258,8 +1288,7 @@ MongoDB.prototype.all = function all(model, filter, options, callback) {
   fields = self.fromPropertyToDatabaseNames(model, fields);
 
   if (fields) {
-    // convert the array of fields into a projection object see http://mongodb.github.io/node-mongodb-native/3.0/api/Collection.html#find
-    var findOpts = {projection: fields};
+    var findOpts = {projection: fieldsArrayToObj(fields)};
     this.execute(model, 'find', query, findOpts, processResponse);
   } else {
     this.execute(model, 'find', query, processResponse);
@@ -1900,10 +1929,12 @@ function optimizedFindOrCreate(model, filter, data, options, callback) {
 
   var sort = self.buildSort(model, filter.order, options);
 
+  var projection = fieldsArrayToObj(filter.fields);
+
   this.collection(model).findOneAndUpdate(
     query,
     {$setOnInsert: data},
-    {projection: filter.fields, sort: sort, upsert: true},
+    {projection: projection, sort: sort, upsert: true},
     function(err, result) {
       if (self.debug) {
         debug('findOrCreate.callback', model, filter, err, result);

--- a/test/persistence-hooks.test.js
+++ b/test/persistence-hooks.test.js
@@ -13,13 +13,6 @@ var customConfig = {
   enableOptimisedfindOrCreate: false,
 };
 
-if (
-  process.env.MONGODB_VERSION &&
-  semver.satisfies(process.env.MONGODB_VERSION, '>= 2.6.0')
-) {
-  customConfig.enableOptimisedfindOrCreate = true;
-}
-
 for (var i in global.config) {
   customConfig[i] = global.config[i];
 }
@@ -34,6 +27,10 @@ if (!DB_VERSION) {
 
 var DB_HAS_2_6_FEATURES =
   !DB_VERSION || semver.satisfies(DB_VERSION, '>=2.6.0');
+
+if (DB_HAS_2_6_FEATURES) {
+  customConfig.enableOptimisedfindOrCreate = true;
+}
 
 suite(global.getDataSource(customConfig), should, {
   replaceOrCreateReportsNewInstance: DB_HAS_2_6_FEATURES,


### PR DESCRIPTION
### Description
Fix provided `projection` option arguments to be provided in **object** expected format to MongoDB library. New object was created in order to avoid tampering with existing fields format that could interfere with different parts of code.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #459 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
