### PR TITLE
Use new url parser by default

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -99,6 +99,7 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   s.safe = s.safe !== false;
   s.w = s.w || 1;
   s.url = s.url || generateMongoDBURL(s);
+  s.useNewUrlParser = s.useNewUrlParser !== false;
   dataSource.connector = new MongoDB(s, dataSource);
   dataSource.ObjectID = mongodb.ObjectID;
 


### PR DESCRIPTION
### Description

In a previous PR (#450) useNewUrlParser was added inside validOptionNames.

As it is deprecated to not use it I think by default this connector should.

(node:20938) DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version. To use the new parser, pass option { useNewUrlParser: true } to MongoClient.connect.

#### Related issues

#442 

### Checklist

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
