### PR TITLE
fix: map new names to old for connector hooks

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -112,6 +112,20 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
   }
 };
 
+// MongoDB has deprecated some commands. To preserve
+// compatibility of model connector hooks, this maps the new
+// commands to previous names for the observors of this command.
+const COMMAND_MAPPINGS = {
+  'insertOne': 'insert',
+  'updateOne': 'save',
+  'findOneAndUpdate': 'findAndModify',
+  'deleteOne': 'delete',
+  'deleteMany': 'delete',
+  'replaceOne': 'update',
+  'updateMany': 'update',
+  'countDocuments': 'count',
+};
+
 exports.MongoDB = MongoDB;
 
 /**
@@ -419,14 +433,14 @@ MongoDB.prototype.execute = function(model, command) {
 
   function doExecute() {
     var collection;
-    var context = {
+    var context = Object.assign({}, {
       model: model,
       collection: collection,
       req: {
         command: command,
         params: args,
       },
-    };
+    });
 
     try {
       collection = self.collection(model);
@@ -434,6 +448,10 @@ MongoDB.prototype.execute = function(model, command) {
       debug('Error: ', err);
       callback(err);
       return;
+    }
+
+    if (command in COMMAND_MAPPINGS) {
+      context.req.command = COMMAND_MAPPINGS[command];
     }
 
     self.notifyObserversAround(

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -805,8 +805,8 @@ describe('mongodb connector', function() {
     ) {
       Post.find(function(err, results) {
         events.should.eql([
-          'before execute insertOne',
-          'after execute insertOne',
+          'before execute insert',
+          'after execute insert',
           'before execute find',
           'after execute find',
         ]);


### PR DESCRIPTION
### Description

Discussed https://github.com/strongloop/loopback-connector-mongodb/pull/461#r217335767 further with @raymondfeng who suggested mapping the new names we emit in the observer to the old ones to prevent this from being a breaking change.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
