### PR TITLE
Fix performance issues on count without filter #464

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -73,6 +73,21 @@ suite
     },
     onComplete: resetTestState,
   })
+  .add('count without filter', {
+    defer: true,
+    fn: function(deferred) {
+      Todo.count(function() {
+        deferred.resolve();
+      });
+    },
+    onStart: function() {
+      const todos = [];
+      for (let i = 0; i < 1000; i++) {
+        todos.push({content: `Buy something ${i}`});
+      }
+      Todo.create(todos);
+    },
+  })
   .on('cycle', function(event) {
     console.log(String(event.target));
   })

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -124,6 +124,7 @@ const COMMAND_MAPPINGS = {
   replaceOne: 'update',
   updateMany: 'update',
   countDocuments: 'count',
+  estimatedDocumentCount: 'count',
 };
 
 exports.MongoDB = MongoDB;
@@ -1368,8 +1369,9 @@ MongoDB.prototype.count = function count(model, where, options, callback) {
   if (self.debug) {
     debug('count', model, where);
   }
-  where = self.buildWhere(model, where, options);
-  this.execute(model, 'countDocuments', where, function(err, count) {
+  where = self.buildWhere(model, where, options) || {};
+  const method = Object.keys(where).length === 0 ? 'estimatedDocumentCount' : 'countDocuments';
+  this.execute(model, method, where, function(err, count) {
     if (self.debug) {
       debug('count.callback', model, err, count);
     }

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -2799,6 +2799,22 @@ describe('mongodb connector', function() {
     });
   });
 
+  it('should support count without where', function(done) {
+    const POST_NUMBER = 35;
+    const posts = [];
+    for (let i = 0; i < POST_NUMBER; i++) {
+      posts.push({title: `My post ${i}`, content: `content ${i}`});
+    }
+
+    Post.create(posts, function() {
+      Post.count(function(err, count) {
+        if (err) return done(err);
+        count.should.be.equal(POST_NUMBER);
+        done();
+      });
+    });
+  });
+
   // The where object should be parsed by the connector
   it('should support where for count', function(done) {
     Post.create({title: 'My Post', content: 'Hello'}, function(err, post) {


### PR DESCRIPTION
### Description
Use estimatedDocumentCount if no filter provided to the count command in order to cancel performance loss since version 3.6.0

#### Related issues
- connect to #464

### Benchmark
Version  | ops/sec
------------ | -------------
3.5.0 | 5,820
3.6.0 | 1,758
3.7.0 | 1,771
PR | 6,029

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)
- [x] New benchmark test
