### PR TITLE
Convert embedded binary properties to buffer

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -365,7 +365,8 @@ MongoDB.prototype.fromDatabase = function(model, data) {
   if (!data) {
     return null;
   }
-  var props = this._models[model].properties;
+  var modelInfo = this._models[model] || this.dataSource.modelBuilder.definitions[model];
+  var props = modelInfo.properties;
   for (var p in props) {
     var prop = props[p];
     if (prop && prop.type === Buffer) {
@@ -389,6 +390,8 @@ MongoDB.prototype.fromDatabase = function(model, data) {
         lat: data[p].coordinates[1],
         lng: data[p].coordinates[0],
       };
+    } else if (prop && prop.type.definition) {
+      data[p] = this.fromDatabase(prop.type.definition.name, data[p]);
     }
   }
 
@@ -1064,8 +1067,8 @@ function convertToMeters(distance, unit) {
     default:
       console.warn(
         'unsupported unit ' +
-          unit +
-          ", fallback to mongodb default unit 'meters'"
+        unit +
+        ", fallback to mongodb default unit 'meters'"
       );
       return distance;
   }

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -28,7 +28,8 @@ var Superhero,
   UserWithRenamedColumns,
   PostWithStringIdAndRenamedColumns,
   Employee,
-  PostWithDisableDefaultSort;
+  PostWithDisableDefaultSort,
+  WithEmbeddedBinaryProperties;
 
 describe('lazyConnect', function() {
   it('should skip connect phase (lazyConnect = true)', function(done) {
@@ -284,6 +285,19 @@ describe('mongodb connector', function() {
       },
       {
         disableDefaultSort: true,
+      }
+    );
+
+    WithEmbeddedBinaryProperties = db.define(
+      'WithEmbeddedBinaryProperties',
+      {
+        name: {type: String},
+        image: {
+          type: {
+            label: String,
+            rawImg: Buffer,
+          },
+        },
       }
     );
 
@@ -637,6 +651,19 @@ describe('mongodb connector', function() {
     User.create({name: 'John', icon: new Buffer('1a2')}, function(e, u) {
       User.findById(u.id, function(e, user) {
         user.icon.should.be.an.instanceOf(Buffer);
+        done();
+      });
+    });
+  });
+
+  it('should convert embedded model binary properties to buffer correctly', function(done) {
+    const entity = {
+      name: 'Rigas',
+      image: {label: 'paris 2016', rawImg: Buffer.from([255, 216, 255, 224])},
+    };
+    WithEmbeddedBinaryProperties.create(entity, function(e, r) {
+      WithEmbeddedBinaryProperties.findById(r.id, function(e, post) {
+        post.image.rawImg.should.be.eql(Buffer.from([255, 216, 255, 224]));
         done();
       });
     });
@@ -1155,7 +1182,7 @@ describe('mongodb connector', function() {
               err.name.should.equal('MongoError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
-                  "field '$rename' in '$rename' is not valid for storage."
+                "field '$rename' in '$rename' is not valid for storage."
               );
               done();
             }
@@ -1180,7 +1207,7 @@ describe('mongodb connector', function() {
               err.name.should.equal('MongoError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
-                  "field '$rename' in '$rename' is not valid for storage."
+                "field '$rename' in '$rename' is not valid for storage."
               );
               done();
             }
@@ -1237,7 +1264,7 @@ describe('mongodb connector', function() {
               err.name.should.equal('MongoError');
               err.errmsg.should.equal(
                 'The dollar ($) prefixed ' +
-                  "field '$rename' in '$rename' is not valid for storage."
+                "field '$rename' in '$rename' is not valid for storage."
               );
               done();
             }
@@ -2921,7 +2948,7 @@ describe('mongodb connector', function() {
 
   it(
     'should support where for count (using renamed columns in deep filter ' +
-      'criteria)',
+    'criteria)',
     function(done) {
       PostWithStringId.create({title: 'My Post', content: 'Hello'}, function(
         err,


### PR DESCRIPTION
### Description
At the conversion of the data from database to JSON only the top level properties where checked for being binary and converted to buffer.
I added a check for a property if is an embedded model and used recursion to loop through these models' properties

#### Related issues
- connect to [#470](https://github.com/strongloop/loopback-connector-mongodb/issues/470)

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
