### PR TITLE
Clean debug output with %o and %O we can use DEBUG_DEPTH now

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -180,7 +180,7 @@ function MongoDB(settings, dataSource) {
   this.debug = settings.debug || debug.enabled;
 
   if (this.debug) {
-    debug('Settings: %j', settings);
+    debug('Settings: %O', settings);
   }
 
   this.dataSource = dataSource;
@@ -299,14 +299,14 @@ MongoDB.prototype.connect = function(callback) {
         validOptions[option] = self.settings[option];
       }
     });
-    debug('Valid options: %j', validOptions);
+    debug('Valid options: %o', validOptions);
     new mongodb.MongoClient(self.settings.url, validOptions).connect(function(
       err,
       client
     ) {
       if (!err) {
         if (self.debug) {
-          debug('MongoDB connection is established: ' + self.settings.url);
+          debug('MongoDB connection is established: %s', self.settings.url);
         }
         self.client = client;
         // The database name might be in the url
@@ -417,6 +417,7 @@ MongoDB.prototype.fromDatabase = function(modelName, data) {
  * @param {Object} data The JSON data to convert
  */
 MongoDB.prototype.toDatabase = function(modelName, data) {
+  const self = this;
   const modelCtor = this._models[modelName];
   const props = modelCtor.properties;
 
@@ -441,7 +442,7 @@ MongoDB.prototype.toDatabase = function(modelName, data) {
   visitAllProperties(data, modelCtor, coercePropertyValue);
   // Override custom column names
   data = this.fromPropertyToDatabaseNames(modelName, data);
-  if (debug.enabled) debug('toDatabase data: ', util.inspect(data));
+  if (self.debug) debug('toDatabase data: %O', data);
   return data;
 };
 
@@ -494,7 +495,7 @@ MongoDB.prototype.execute = function(modelName, command) {
     try {
       collection = self.collection(modelName);
     } catch (err) {
-      debug('Error: ', err);
+      debug('Error: %o', err);
       callback(err);
       return;
     }
@@ -509,14 +510,14 @@ MongoDB.prototype.execute = function(modelName, command) {
       function(context, done) {
         args[args.length - 1] = function(err, result) {
           if (err) {
-            debug('Error: ', err);
+            debug('Error: %o', err);
           } else {
             context.res = result;
-            debug('Result: ', result);
+            debug('Result: %o', result);
           }
           done(err, result);
         };
-        debug('MongoDB: model=%s command=%s', modelName, command, args);
+        debug('MongoDB: modelName=%s command=%s args=%o', modelName, command, args);
         return collection[command].apply(collection, args);
       },
       callback
@@ -558,7 +559,7 @@ MongoDB.prototype.coerceId = function(modelName, id, options) {
 MongoDB.prototype.create = function(modelName, data, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('create', modelName, data);
+    debug('create modelName=%s data=%O', modelName, data);
   }
   let idValue = self.getIdValue(modelName, data);
   const idName = self.idName(modelName);
@@ -577,7 +578,7 @@ MongoDB.prototype.create = function(modelName, data, options, callback) {
 
   this.execute(modelName, 'insertOne', data, {safe: true}, function(err, result) {
     if (self.debug) {
-      debug('create.callback', modelName, err, result);
+      debug('create.callback modelName=%s error=%O result=%O', modelName, err, result);
     }
     if (err) {
       return callback(err);
@@ -604,7 +605,7 @@ MongoDB.prototype.create = function(modelName, data, options, callback) {
 MongoDB.prototype.save = function(modelName, data, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('save', modelName, data);
+    debug('save modelName=%s data=%O', modelName, data);
   }
   const idValue = self.getIdValue(modelName, data);
   const idName = self.idName(modelName);
@@ -625,7 +626,7 @@ MongoDB.prototype.save = function(modelName, data, options, callback) {
       }
     }
     if (self.debug) {
-      debug('save.callback', modelName, err, result);
+      debug('save.callback modelName=%s err=%O result=%O', modelName, err, result);
     }
 
     const info = {};
@@ -640,7 +641,7 @@ MongoDB.prototype.save = function(modelName, data, options, callback) {
       if (result.result.ok === 1 && result.result.n === 1) {
         info.isNewInstance = !!result.result.upserted;
       } else {
-        debug('save result format not recognized: %j', result.result);
+        debug('save result format not recognized: %o', result.result);
       }
     }
 
@@ -660,12 +661,12 @@ MongoDB.prototype.save = function(modelName, data, options, callback) {
 MongoDB.prototype.exists = function(modelName, id, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('exists', modelName, id);
+    debug('exists modelName=%s id=%s', modelName, id);
   }
   id = self.coerceId(modelName, id, options);
   this.execute(modelName, 'findOne', {_id: id}, function(err, data) {
     if (self.debug) {
-      debug('exists.callback', modelName, id, err, data);
+      debug('exists.callback modelName=%s id=%s err=%O data=%O', modelName, id, err, data);
     }
     callback(err, !!(!err && data));
   });
@@ -680,13 +681,13 @@ MongoDB.prototype.exists = function(modelName, id, options, callback) {
 MongoDB.prototype.find = function find(modelName, id, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('find', modelName, id);
+    debug('find modelName=%s id=%s', modelName, id);
   }
   const idName = self.idName(modelName);
   const oid = self.coerceId(modelName, id, options);
   this.execute(modelName, 'findOne', {_id: oid}, function(err, data) {
     if (self.debug) {
-      debug('find.callback', modelName, id, err, data);
+      debug('find.callback modelName=%s id=%s err=%O data=%O', modelName, id, err, data);
     }
 
     data = self.fromDatabase(modelName, data);
@@ -788,7 +789,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
 ) {
   const self = this;
   if (self.debug) {
-    debug('updateOrCreate', modelName, data);
+    debug('updateOrCreate modelName=%s data=%O', modelName, data);
   }
 
   const id = self.getIdValue(modelName, data);
@@ -815,7 +816,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
     },
     function(err, result) {
       if (self.debug) {
-        debug('updateOrCreate.callback', modelName, id, err, result);
+        debug('updateOrCreate.callback modelName=%s id=%s err=%O result=%O', modelName, id, err, result);
       }
       const object = result && result.value;
       if (!err && !object) {
@@ -833,7 +834,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
       if (result && result.lastErrorObject) {
         info = {isNewInstance: !result.lastErrorObject.updatedExisting};
       } else {
-        debug('updateOrCreate result format not recognized: %j', result);
+        debug('updateOrCreate result format not recognized: %o', result);
       }
 
       if (callback) {
@@ -852,7 +853,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
  * @param {Function} [cb] The callback function
  */
 MongoDB.prototype.replaceOrCreate = function(modelName, data, options, cb) {
-  if (this.debug) debug('replaceOrCreate', modelName, data);
+  if (this.debug) debug('replaceOrCreate modelName=%s data=%O', modelName, data);
 
   const id = this.getIdValue(modelName, data);
   const oid = this.coerceId(modelName, id, options);
@@ -871,12 +872,12 @@ MongoDB.prototype.replaceOrCreate = function(modelName, data, options, cb) {
 MongoDB.prototype.destroy = function destroy(modelName, id, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('delete', modelName, id);
+    debug('delete modelName=%s id=%s', modelName, id);
   }
   id = self.coerceId(modelName, id, options);
   this.execute(modelName, 'deleteOne', {_id: id}, function(err, result) {
     if (self.debug) {
-      debug('delete.callback', modelName, id, err, result);
+      debug('delete.callback modelName=%s id=%s err=%O result=%O', modelName, id, err, result);
     }
     let res = result && result.result;
     if (res) {
@@ -1300,7 +1301,7 @@ MongoDB.prototype.fromDatabaseToPropertyNames = function(model, data) {
 MongoDB.prototype.all = function all(modelName, filter, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('all', modelName, filter);
+    debug('all modelName=%s filter=%O', modelName, filter);
   }
   filter = filter || {};
   const idName = self.idName(modelName);
@@ -1350,7 +1351,7 @@ MongoDB.prototype.all = function all(modelName, filter, options, callback) {
 
     cursor.toArray(function(err, data) {
       if (self.debug) {
-        debug('all', modelName, filter, err, data);
+        debug('all modelName=%s filter=%O err=%O data=%O', modelName, filter, err, data);
       }
       if (err) {
         return callback(err);
@@ -1395,19 +1396,19 @@ MongoDB.prototype.destroyAll = function destroyAll(
 ) {
   const self = this;
   if (self.debug) {
-    debug('destroyAll', modelName, where);
+    debug('destroyAll modelName=%s where=%O', modelName, where);
   }
   if (!callback && 'function' === typeof where) {
     callback = where;
     where = undefined;
   }
   where = self.buildWhere(modelName, where, options);
-  if (debug.enabled) debug('destroyAll where %s', util.inspect(where));
+  if (debug.enabled) debug('destroyAll.buildWhere modelName=%s where=%O', modelName, where);
 
   this.execute(modelName, 'deleteMany', where || {}, function(err, info) {
     if (err) return callback && callback(err);
 
-    if (self.debug) debug('destroyAll.callback', modelName, where, err, info);
+    if (self.debug) debug('destroyAll.callback modelName=%s where=%O err=%O info=%O', modelName, where, err, info);
 
     const affectedCount = info.result ? info.result.n : undefined;
 
@@ -1428,13 +1429,13 @@ MongoDB.prototype.destroyAll = function destroyAll(
 MongoDB.prototype.count = function count(modelName, where, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('count', modelName, where);
+    debug('count modelName=%s where=%O', modelName, where);
   }
   where = self.buildWhere(modelName, where, options) || {};
   const method = Object.keys(where).length === 0 ? 'estimatedDocumentCount' : 'countDocuments';
   this.execute(modelName, method, where, function(err, count) {
     if (self.debug) {
-      debug('count.callback', modelName, err, count);
+      debug('count.callback modelName=%s err=%O count=%d', modelName, err, count);
     }
     if (callback) {
       callback(err, count);
@@ -1451,7 +1452,7 @@ MongoDB.prototype.count = function count(modelName, where, options, callback) {
  * @param {Function} [cb] The callback function
  */
 MongoDB.prototype.replaceById = function replace(modelName, id, data, options, cb) {
-  if (this.debug) debug('replace', modelName, id, data);
+  if (this.debug) debug('replace modelName=%s id=%s data=%O options=%O', modelName, id, data, options);
   const oid = this.coerceId(modelName, id, options);
   this.replaceWithOptions(modelName, oid, data, {upsert: false}, function(
     err,
@@ -1485,7 +1486,7 @@ MongoDB.prototype.replaceWithOptions = function(modelName, id, data, options, cb
     err,
     info
   ) {
-    debug('updateWithOptions.callback', modelName, {_id: id}, data, err, info);
+    debug('updateWithOptions.callback modelName=%s _id=%s data=%o err=%o info=%o', modelName, id, data, err, info);
     if (err) return cb && cb(err);
     let result;
     const cbInfo = {};
@@ -1534,7 +1535,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(
   data = self.parseUpdateData(modelName, data, options);
 
   if (self.debug) {
-    debug('updateAttributes', modelName, id, data);
+    debug('updateAttributes modelName=%s id=%s data=%O', modelName, id, data);
   }
 
   if (Object.keys(data).length === 0) {
@@ -1561,7 +1562,7 @@ MongoDB.prototype.updateAttributes = function updateAttrs(
     },
     function(err, result) {
       if (self.debug) {
-        debug('updateAttributes.callback', modelName, id, err, result);
+        debug('updateAttributes.callback modelName=%s id=%s err=%O result=%O', modelName, id, err, result);
       }
       const object = result && result.value;
       if (!err && !object) {
@@ -1602,7 +1603,7 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
 ) {
   const self = this;
   if (self.debug) {
-    debug('updateAll', modelName, where, data);
+    debug('updateAll modelName=%s where=%O data=%O', modelName, where, data);
   }
   const idName = this.idName(modelName);
 
@@ -1624,9 +1625,9 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
     function(err, info) {
       if (err) return cb && cb(err);
 
-      if (self.debug)
-        debug('updateAll.callback', modelName, where, updateData, err, info);
-
+      if (self.debug) {
+        debug('updateAll.callback modelName=%s where=%O data=%O err=%O info=%O', modelName, where, data, err, info);
+      }
       const affectedCount = info.result ? info.result.n : undefined;
 
       if (cb) {
@@ -1760,14 +1761,14 @@ MongoDB.prototype.autoupdate = function(models, cb) {
         /* eslint-enable one-var */
 
         if (self.debug) {
-          debug('create indexes: ', indexList);
+          debug('create indexes: %O', indexList);
         }
 
         async.each(
           indexList,
           function(index, indexCallback) {
             if (self.debug) {
-              debug('createIndex: ', index);
+              debug('createIndex: %O', index);
             }
             self
               .collection(modelName)
@@ -1824,7 +1825,7 @@ MongoDB.prototype.automigrate = function(models, cb) {
         self.db.dropCollection(collectionName, function(err, collection) {
           if (err) {
             debug(
-              'Error dropping collection %s for model %s: ',
+              'Error dropping collection %s for model %s: %o',
               collectionName,
               modelName,
               err
@@ -1973,7 +1974,7 @@ exports.sanitizeFilter = sanitizeFilter;
 function optimizedFindOrCreate(modelName, filter, data, options, callback) {
   const self = this;
   if (self.debug) {
-    debug('findOrCreate', modelName, filter, data);
+    debug('findOrCreate modelName=%s filter=%O data=%O', modelName, filter, data);
   }
 
   if (!callback) callback = options;
@@ -2013,7 +2014,7 @@ function optimizedFindOrCreate(modelName, filter, data, options, callback) {
     {projection: projection, sort: sort, upsert: true},
     function(err, result) {
       if (self.debug) {
-        debug('findOrCreate.callback', modelName, filter, err, result);
+        debug('findOrCreate.callback modelName=%s filter=%O err=%O result=%O', modelName, filter, err, result);
       }
       if (err) {
         return callback(err);


### PR DESCRIPTION
### Description
I change all the `debug()` lines with [formatters](https://www.npmjs.com/package/debug#formatters) `%o` or `%O`.

#### Why
1. We can now use all the options handled by `debug` => [util.inspect](https://nodejs.org/api/util.html#util_util_inspect_object_options) especially `DEBUG_DEPTH`
1. Proper syntax highlight
1. Proper indentation of debug lines
1. We can now used debug like that `DEBUG="loopback:connector:mongodb" DEBUG_DEPTH=0 npm run test -- -g sometest`

#### What I have done

- All the debug lines surrounded by `if(self.debug)` I used `%O` which print multi-line.
- All other debug lines not activated with the debug flag, I used the `%o` which print on a single line.
- I replace `%j` per `%O` or `%o`.
- I add some variable names like `command model=%s data=%O`.


#### Related issues

- connect to maybe #229

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
