### PR TITLE
remove the infinite inspect

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -431,7 +431,7 @@ MongoDB.prototype.toDatabase = function(model, data) {
   convertDecimalProps(data, props);
   // Override custom column names
   data = this.fromPropertyToDatabaseNames(model, data);
-  debug('toDatabase data: ', util.inspect(data, {depth: null}));
+  if (debug.enabled) debug('toDatabase data: ', util.inspect(data));
   return data;
 };
 
@@ -1392,7 +1392,7 @@ MongoDB.prototype.destroyAll = function destroyAll(
     where = undefined;
   }
   where = self.buildWhere(model, where, options);
-  debug('destroyAll where %s', util.inspect(where, {depth: null}));
+  if (debug.enabled) debug('destroyAll where %s', util.inspect(where));
 
   this.execute(model, 'deleteMany', where || {}, function(err, info) {
     if (err) return callback && callback(err);
@@ -2002,7 +2002,7 @@ function optimizedFindOrCreate(model, filter, data, options, callback) {
  * @param {Object} props The model property definitions
  */
 function convertDecimalProps(data, props) {
-  debug('convertDecimalProps props: ', util.inspect(props, {depth: null}));
+  if (debug.enabled) debug('convertDecimalProps props: ', util.inspect(props));
   for (const p in props) {
     const prop = props[p];
     const isDecimal = data[p] && prop && prop.mongodb &&


### PR DESCRIPTION
### Description

Fix https://github.com/strongloop/loopback-connector-mongodb/issues/479
The default `depth` is 4, not infinite.
#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
