### PR TITLE
fix $where

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can set the `url` property to a connection URL in `datasources.json` to over
 Additionally, you can override the global `url` property in environment-specific data source configuration files, for example for production in `datasources.production.json`, and use the individual connection parameters `host`, `user`, `password`, and `port`.  To do this, you _must_ set `url` to `false`, null, or “” (empty string).
 If you set `url` to `undefined` or remove the `url` property altogether, the override will not work.
 
-For example, for production, use `datasources.production.json` as follows (for example) to overide the `url` setting in `datasources.json:
+For example, for production, use `datasources.production.json` as follows (for example) to override the `url` setting in `datasources.json:
 
 ```javascript
 "mydb": {

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -951,6 +951,7 @@ MongoDB.prototype.buildWhere = function(model, where, options) {
       cond = cond[spec];
     }
     if (spec) {
+      if (spec.charAt(0) === '$') spec = spec.substr(1);
       if (spec === 'between') {
         query[k] = {$gte: cond[0], $lte: cond[1]};
       } else if (spec === 'inq') {
@@ -990,8 +991,6 @@ MongoDB.prototype.buildWhere = function(model, where, options) {
           g.warn('{{MongoDB}} regex syntax does not respect the {{`g`}} flag');
 
         query[k] = {$regex: cond};
-      } else if (spec === '$where') {
-        query[k] = {$where: cond};
       } else {
         query[k] = {};
         query[k]['$' + spec] = cond;

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -990,6 +990,8 @@ MongoDB.prototype.buildWhere = function(model, where, options) {
           g.warn('{{MongoDB}} regex syntax does not respect the {{`g`}} flag');
 
         query[k] = {$regex: cond};
+      } else if (spec === '$where') {
+        query[k] = {$where: cond};
       } else {
         query[k] = {};
         query[k]['$' + spec] = cond;

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -778,12 +778,13 @@ describe('mongodb connector', function() {
   });
 
   it('does not execute a nested `$where`', function(done) {
+    const filter = {where: {content: {$where: 'function() {return this.content.contains("content")}'}}};
+
     Post.create({title: 'Post1', content: 'Post1 content'}, (err, p1) => {
       Post.create({title: 'Post2', content: 'Post2 content'}, (err2, p2) => {
         Post.create({title: 'Post3', content: 'Post3 data'}, (err3, p3) => {
-          Post.find({where: {content: {$where: 'function() {return this.content.contains("content")}'}}}, (err, p) => {
-            should.not.exist(err);
-            p.length.should.be.equal(0);
+          Post.find(filter, {allowExtendedOperators: true}, (err, p) => {
+            should.exist(err);
             done();
           });
         });

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -785,6 +785,7 @@ describe('mongodb connector', function() {
         Post.create({title: 'Post3', content: 'Post3 data'}, (err3, p3) => {
           Post.find(filter, {allowExtendedOperators: true}, (err, p) => {
             should.exist(err);
+            err.message.should.match(/^\$where/);
             done();
           });
         });


### PR DESCRIPTION
### Description

Fix test failure in https://github.com/strongloop/loopback-connector-mongodb/pull/483

According to [this juggler PR which introduced a flag to allow extended operators](https://github.com/strongloop/loopback-datasource-juggler/commit/a761e0d114486ea547ad0ae4391cfa3faccc9580#diff-d717a01e40d8164976e4468af1bce663R1845), the original test fails because `allowExtendedOperators` defaults to `false`, `Post.find()` throws "OPERATOR_NOT_ALLOWED_IN_QUERY" error instead of ignoring the nested `$where` filter.

I think the test was aimed at making sure the nested `$where` is not executed when  `allowExtendedOperators` is true, so set the flag to true in this fix PR. 

I don't know how the test passed before without throwing error. Without my change in the `buildWhere` function, it adds an additional `$` to the `$where`, resulting in mongodb driver throws "invalid operator $$where", which also makes sense. 

I am ok to either keep/remove my change in `buildWhere` function because they both prevents executing the nested `$where`. Opinions are welcomed :)

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
