### PR TITLE
test: remove decimal coercion from queries

### DIFF
--- a/test/decimal.test.js
+++ b/test/decimal.test.js
@@ -169,7 +169,7 @@ describe('decimal128', function() {
     });
 
     it('find - filters nested object decimal property', function(done) {
-      const cond = {where: {'summary.totalValue': Decimal128.fromString('100.0005')}};
+      const cond = {where: {'summary.totalValue': '100.0005'}};
       OrderDecimalObj.find(cond, function(err, orders) {
         if (err) return done(err);
         orders.length.should.be.above(0);
@@ -183,7 +183,7 @@ describe('decimal128', function() {
       const anotherSample = {
         summary: {totalValue: '100.0006'},
       };
-      const cond = {'summary.totalValue': Decimal128.fromString('100.0005')};
+      const cond = {'summary.totalValue': '100.0005'};
       OrderDecimalObj.create(anotherSample)
         .then(function() {
           return OrderDecimalObj.destroyAll(cond);


### PR DESCRIPTION
### Description
Following the fix in `loopback-connector` to get nested property definitions in https://github.com/strongloop/loopback-connector/pull/136/ and https://github.com/strongloop/loopback-connector/pull/138, we need to modify tests calling find/delete to not coerce queries into decimal values. Before there was a limitation where we receive `undefined` for the property definition for nested properties, but now we can call these functions using string values as intended in the docs.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
