### PR TITLE
Fix/nested decimal props

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -409,10 +409,11 @@ MongoDB.prototype.fromDatabase = function(model, data) {
  * @param {Object} data The JSON data to convert
  */
 MongoDB.prototype.toDatabase = function(model, data) {
+  const modelInstance = this._models[model].model;
   var props = this._models[model].properties;
 
   if (this.settings.enableGeoIndexing !== true) {
-    convertDecimalProps(data, props);
+    visitAllProperties(data, modelInstance, coerceDecimalProperty);
     // Override custom column names
     data = this.fromPropertyToDatabaseNames(model, data);
     return data;
@@ -429,7 +430,7 @@ MongoDB.prototype.toDatabase = function(model, data) {
     }
   }
 
-  convertDecimalProps(data, props);
+  visitAllProperties(data, modelInstance, coerceDecimalProperty);
   // Override custom column names
   data = this.fromPropertyToDatabaseNames(model, data);
   if (debug.enabled) debug('toDatabase data: ', util.inspect(data));
@@ -1996,23 +1997,75 @@ function optimizedFindOrCreate(model, filter, data, options, callback) {
 }
 
 /**
- * Convert the decimal properties from string to decimal.
- * Only supported after mongodb 3.4
  *
- * @param {Object} data The data that might contain a decimal property
- * @param {Object} props The model property definitions
+ * @param {*} data Plain Data Object for the matching property definition(s)
+ * @param {*} modelCtorOrDef Model constructor or definition
+ * @param {*} visitor A callback function which takes a property value and
+ * definition to apply custom property coercion
  */
-function convertDecimalProps(data, props) {
-  if (debug.enabled) debug('convertDecimalProps props: ', util.inspect(props));
-  for (const p in props) {
-    const prop = props[p];
-    const isDecimal = data[p] && prop && prop.mongodb &&
-      prop.mongodb.dataType &&
-      prop.mongodb.dataType.toLowerCase() === 'decimal128';
-    if (isDecimal) {
-      data[p] = Decimal128.fromString(data[p]);
-      debug('convertDecimalProps decimal value: ', data[p]);
+function visitAllProperties(data, modelCtorOrDef, visitor) {
+  if (data === null || data === undefined) return;
+  const modelProps = modelCtorOrDef.properties ? modelCtorOrDef.properties : modelCtorOrDef.definition.properties;
+  const allProps = new Set(Object.keys(data).concat(Object.keys(modelProps)));
+  for (const p of allProps) {
+    const value = data[p];
+    const def = modelProps[p];
+    if (def && def.type && isNestedModel(def.type)) {
+      if (Array.isArray(def.type)) {
+        if (value === null || value === undefined) break;
+        for (const it of value) {
+          visitAllProperties(it, def.type[0].definition, visitor);
+        }
+      } else {
+        if (value === null) break;
+        visitAllProperties(value, def.type.definition, visitor);
+      }
+    } else {
+      visitor(value, def, (newValue) => { data[p] = newValue; });
     }
   }
-  return data;
 }
+
+/**
+ *
+ * @param {*} propValue Property value to coerce into a Decimal128 value
+ * @param {*} propDef Property definition to check if property is MongoDB
+ * Decimal128 type
+ */
+function coerceDecimalProperty(propValue, propDef, setValue) {
+  let updatedValue;
+  if (hasDataType('decimal128', propDef)) {
+    if (Array.isArray(propValue)) {
+      updatedValue = propValue.map(val => Decimal128.fromString(val));
+      return setValue(updatedValue);
+    } else {
+      updatedValue = Decimal128.fromString(propValue);
+      return setValue(updatedValue);
+    }
+  }
+}
+
+/**
+* A utility function which checks for nested property definitions
+*
+* @param {*} propType Property type metadata
+*
+*/
+function isNestedModel(propType) {
+  if (!propType) return false;
+  if (Array.isArray(propType)) return isNestedModel(propType[0]);
+  return propType.definition && propType.definition.properties;
+}
+
+/**
+* A utility function which checks if a certain property definition matches
+* the given data type
+* @param {*} dataType The data type to check the property definition against
+* @param {*} propertyDef A property definition containing metadata about property type
+*/
+function hasDataType(dataType, propertyDef) {
+  return propertyDef && propertyDef.mongodb &&
+    propertyDef.mongodb.dataType &&
+    propertyDef.mongodb.dataType.toLowerCase() === dataType.toLowerCase();
+}
+

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "bluebird": "^3.5.2",
+    "bluebird": "^3.5.4",
     "eslint": "^5.1.0",
     "eslint-config-loopback": "^10.0.0",
     "loopback-datasource-juggler": "^3.23.0",

--- a/test/decimal.test.js
+++ b/test/decimal.test.js
@@ -6,6 +6,7 @@
 'use strict';
 
 require('./init.js');
+const promisify = require('bluebird').promisify;
 const Decimal128 = require('mongodb').Decimal128;
 
 var db, OrderDecimal;
@@ -48,8 +49,8 @@ describe('model with decimal property', function() {
     });
   });
 
-  it('destroyAll - deletes all with where', function(done) {
-    OrderDecimal.create({count: '0.0006'})
+  it('destroyAll - deletes all with where', function() {
+    return OrderDecimal.create({count: '0.0006'})
       .then(function() {
         return OrderDecimal.destroyAll({count: '0.0005'});
       })
@@ -59,8 +60,426 @@ describe('model with decimal property', function() {
       .then(function(r) {
         r.length.should.equal(1);
         r[0].count.should.deepEqual(Decimal128.fromString('0.0006'));
-        done();
-      })
-      .catch(done);
+      });
+  });
+
+  context('nested decimal props', function() {
+    it('should create/update instance for array of decimal props', function() {
+      const modelWithDecimalArray = db.define('modelWithDecimalArray', {
+        randomReview: {
+          type: [String],
+          mongodb: {
+            dataType: 'Decimal128',
+          },
+        },
+      }, {
+        updateOnLoad: true,
+      });
+
+      var createData = {
+        'randomReview': [
+          '3.5',
+          '4.5',
+          '4.0',
+        ],
+      };
+      var updateData = {
+        'randomReview': [
+          '5.5',
+          '5.5',
+          '5.5',
+        ],
+      };
+      let instanceId;
+
+      return modelWithDecimalArray.create(createData)
+        .then(function(inst) {
+          instanceId = inst.id;
+          return findRawModelDataAsync('modelWithDecimalArray', instanceId);
+        })
+        .then(function(createdInstance) {
+          createdInstance.randomReview[0].should.be.instanceOf(Decimal128);
+          createdInstance.randomReview[0].should.deepEqual(Decimal128.fromString('3.5'));
+          return modelWithDecimalArray.updateAll({id: instanceId}, updateData);
+        })
+        .then(function(inst) {
+          return findRawModelDataAsync('modelWithDecimalArray', instanceId);
+        })
+        .then(function(updatedInstance) {
+          updatedInstance.randomReview[0].should.be.instanceOf(Decimal128);
+          updatedInstance.randomReview[0].should.deepEqual(Decimal128.fromString('5.5'));
+        });
+    });
+    it('should create/update instance for nested decimal prop inside array', function() {
+      const modelWithDecimalNestedArray = db.define('modelWithDecimalNestedArray', {
+        tickets: {
+          type: [
+            {
+              theatre: {
+                type: String,
+              },
+              unitprice: {
+                type: String,
+                mongodb: {
+                  dataType: 'Decimal128',
+                },
+              },
+              capacity: {
+                type: Number,
+              },
+            },
+          ],
+        },
+      });
+      const createData = {
+        'tickets': [
+          {
+            'theatre': 'AMC',
+            'capacity': '205',
+            'unitprice': '19.5',
+          },
+          {
+            'theatre': 'IMAX',
+            'capacity': '300',
+            'unitprice': '39.5',
+          },
+        ],
+      };
+
+      const updateData = {
+        'tickets': [
+          {
+            'theatre': 'Cineplex',
+            'capacity': '500',
+            'unitprice': '27.5',
+          },
+          {
+            'theatre': 'Cineplex 3D',
+            'capacity': '500',
+            'unitprice': '45.50',
+          },
+        ],
+      };
+      let instanceId;
+
+      return modelWithDecimalNestedArray.create(createData)
+        .then(function(inst) {
+          instanceId = inst.id;
+          return findRawModelDataAsync('modelWithDecimalNestedArray', instanceId);
+        })
+        .then(function(createdInstance) {
+          createdInstance.tickets[0].unitprice.should.be.instanceOf(Decimal128);
+          createdInstance.tickets[0].unitprice.should.deepEqual(Decimal128.fromString('19.5'));
+          return modelWithDecimalNestedArray.updateAll({id: instanceId}, updateData);
+        })
+        .then(function(inst) {
+          return findRawModelDataAsync('modelWithDecimalNestedArray', instanceId);
+        })
+        .then(function(updatedInstance) {
+          updatedInstance.tickets[0].unitprice.should.be.instanceOf(Decimal128);
+          updatedInstance.tickets[0].unitprice.should.deepEqual(Decimal128.fromString('27.5'));
+        });
+    });
+
+    it('should create/update instance for nested decimal prop inside object', function() {
+      const modelWithDecimalNestedObject = db.define('modelWithDecimalNestedObject', {
+        awards: {
+          type: {
+            wins: {
+              type: Number,
+            },
+            prizeMoney: {
+              type: String,
+              mongodb: {
+                dataType: 'Decimal128',
+              },
+            },
+            currency: {
+              type: String,
+            },
+          },
+        },
+      });
+      const createData = {
+        'awards': {
+          'currency': 'USD',
+          'wins': '4',
+          'prizeMoney': '10000.00',
+        },
+      };
+
+      const updateData = {
+        'awards': {
+          'currency': 'CAD',
+          'wins': '10',
+          'prizeMoney': '25000.00',
+        },
+      };
+
+      let instanceId;
+
+      return modelWithDecimalNestedObject.create(createData)
+        .then(function(inst) {
+          instanceId = inst.id;
+          return findRawModelDataAsync('modelWithDecimalNestedObject', instanceId);
+        })
+        .then(function(createdInstance) {
+          createdInstance.awards.prizeMoney.should.be.instanceOf(Decimal128);
+          createdInstance.awards.prizeMoney.should.deepEqual(Decimal128.fromString('10000.00'));
+          return modelWithDecimalNestedObject.updateAll({id: instanceId}, updateData);
+        })
+        .then(function() {
+          return findRawModelDataAsync('modelWithDecimalNestedObject', instanceId);
+        })
+        .then(function(updatedInstance) {
+          updatedInstance.awards.prizeMoney.should.be.instanceOf(Decimal128);
+          updatedInstance.awards.prizeMoney.should.deepEqual(Decimal128.fromString('25000.00'));
+        });
+    });
+    it('should create/update instance for deeply nested decimal props', function() {
+      const modelWithDeepNestedDecimalProps = db.define('modelWithDeepNestedDecimalProps', {
+        imdb: {
+          type: {
+            duration: {
+              type: Number,
+            },
+            reviewDate: {
+              type: Date,
+            },
+            rating: {
+              type: String,
+              mongodb: {
+                dataType: 'Decimal128',
+              },
+            },
+            innerArray: [
+              {
+                testNumber: {
+                  type: Number,
+                },
+                testDate: {
+                  type: Date,
+                },
+                testDecimal: {
+                  type: String,
+                  mongodb: {
+                    dataType: 'Decimal128',
+                  },
+                },
+                ObjInsideAnArray: {
+                  testNumber: {
+                    type: Number,
+                  },
+                  testDate: {
+                    type: Date,
+                  },
+                  testDecimal: {
+                    type: String,
+                    mongodb: {
+                      dataType: 'Decimal128',
+                    },
+                  },
+                },
+                nestedArray: [
+                  {
+                    testNumber: {
+                      type: Number,
+                    },
+                    testDate: {
+                      type: Date,
+                    },
+                    testDecimal: {
+                      type: String,
+                      mongodb: {
+                        dataType: 'Decimal128',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            innerObj: {
+              innerObj: {
+                innerObj: {
+                  innerObj: {
+                    testNumber: {
+                      type: Number,
+                    },
+                    testDate: {
+                      type: Date,
+                    },
+                    testDecimal: {
+                      type: String,
+                      mongodb: {
+                        dataType: 'Decimal128',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+      const createData = {
+        'imdb': {
+          'reviewDate': '2019-01-29T04:00:39.828Z',
+          'innerArray': [
+            {
+              'ObjInsideAnArray': {
+                'testNumber': '1234',
+                'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                'testDecimal': '99.55',
+              },
+              'nestedArray': [
+                {
+                  'testNumber': '1234',
+                  'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                  'testDecimal': '99.55',
+                },
+                {
+                  'testNumber': '1234',
+                  'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                  'testDecimal': '99.55',
+                },
+              ],
+              'testNumber': '1234',
+              'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+              'testDecimal': '99.55',
+            },
+            {
+              'ObjInsideAnArray': null,
+              'nestedArray': null,
+              'testNumber': '5678',
+              'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+              'testDecimal': '99.55',
+            },
+          ],
+          'innerObj': {
+            'innerObj': {
+              'innerObj': {
+                'innerObj': {
+                  'testNumber': '6666',
+                  'testDate': '2019-01-30 18:26:38.551022',
+                  'testDecimal': '55.55',
+                },
+              },
+            },
+          },
+          'duration': '135',
+          'rating': '4.5',
+        },
+      };
+
+      const updateData = {
+        'imdb': {
+          'reviewDate': '2019-01-29T04:00:39.828Z',
+          'innerArray': [
+            {
+              'ObjInsideAnArray': {
+                'testNumber': '7777',
+                'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                'testDecimal': '77.77',
+              },
+              'nestedArray': [
+                {
+                  'testNumber': '7777',
+                  'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                  'testDecimal': '77.77',
+                },
+                {
+                  'testNumber': '7777',
+                  'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                  'testDecimal': '77.77',
+                },
+              ],
+              'testNumber': '7777',
+              'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+              'testDecimal': '11.11',
+            },
+            {
+              'ObjInsideAnArray': {
+                'testNumber': '7777',
+                'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+                'testDecimal': '77.77',
+              },
+              'nestedArray': null,
+              'testNumber': '7777',
+              'testDate': "TIMESTAMP '2019-01-30 18:26:38.551022'",
+              'testDecimal': '22.22',
+            },
+          ],
+          'innerObj': {
+            'innerObj': {
+              'innerObj': {
+                'innerObj': {
+                  'testNumber': '7777',
+                  'testDate': '2019-01-30 18:26:38.551022',
+                  'testDecimal': '77.77',
+                },
+              },
+            },
+          },
+          'duration': '135',
+          'rating': '7.5',
+        },
+      };
+      let instanceId;
+
+      return modelWithDeepNestedDecimalProps.create(createData)
+        .then(function(inst) {
+          instanceId = inst.id;
+          return findRawModelDataAsync('modelWithDeepNestedDecimalProps', instanceId);
+        })
+        .then(function(createdInstance) {
+          createdInstance.imdb.rating.should.be.instanceOf(Decimal128);
+          createdInstance.imdb.rating.should.deepEqual(Decimal128.fromString('4.5'));
+          createdInstance.imdb.innerObj.innerObj.innerObj.innerObj.testDecimal
+            .should.be.instanceOf(Decimal128);
+          createdInstance.imdb.innerObj.innerObj.innerObj.innerObj.testDecimal
+            .should.deepEqual(Decimal128.fromString('55.55'));
+          createdInstance.imdb.innerArray[0].testDecimal
+            .should.be.instanceOf(Decimal128);
+          createdInstance.imdb.innerArray[0].testDecimal
+            .should.deepEqual(Decimal128.fromString('99.55'));
+          createdInstance.imdb.innerArray[0].ObjInsideAnArray.testDecimal
+            .should.deepEqual(Decimal128.fromString('99.55'));
+          createdInstance.imdb.innerArray[0].ObjInsideAnArray.testDecimal
+            .should.be.instanceOf(Decimal128);
+          createdInstance.imdb.innerArray[0].nestedArray[0]
+            .testDecimal.should.be.instanceOf(Decimal128);
+          createdInstance.imdb.innerArray[0].nestedArray[0]
+            .testDecimal.should.deepEqual(Decimal128.fromString('99.55'));
+          return modelWithDeepNestedDecimalProps.updateAll({id: instanceId}, updateData);
+        })
+        .then(function() {
+          return findRawModelDataAsync('modelWithDeepNestedDecimalProps', instanceId);
+        })
+        .then(function(updatedInstance) {
+          updatedInstance.imdb.rating.should.be.instanceOf(Decimal128);
+          updatedInstance.imdb.rating.should.deepEqual(Decimal128.fromString('7.5'));
+          updatedInstance.imdb.innerObj.innerObj.innerObj.innerObj.testDecimal
+            .should.be.instanceOf(Decimal128);
+          updatedInstance.imdb.innerObj.innerObj.innerObj.innerObj.testDecimal
+            .should.deepEqual(Decimal128.fromString('77.77'));
+          updatedInstance.imdb.innerArray[0].testDecimal
+            .should.be.instanceOf(Decimal128);
+          updatedInstance.imdb.innerArray[0].testDecimal
+            .should.deepEqual(Decimal128.fromString('11.11'));
+          updatedInstance.imdb.innerArray[0].ObjInsideAnArray.testDecimal
+            .should.deepEqual(Decimal128.fromString('77.77'));
+          updatedInstance.imdb.innerArray[0].ObjInsideAnArray.testDecimal
+            .should.be.instanceOf(Decimal128);
+          updatedInstance.imdb.innerArray[0].nestedArray[0]
+            .testDecimal.should.be.instanceOf(Decimal128);
+          updatedInstance.imdb.innerArray[0].nestedArray[0]
+            .testDecimal.should.deepEqual(Decimal128.fromString('77.77'));
+        });
+    });
+
+    function findRawModelData(modelName, id, cb) {
+      db.connector.execute(modelName, 'findOne', {_id: {$eq: id}}, {safe: true}, cb);
+    }
+    const findRawModelDataAsync = promisify(findRawModelData);
   });
 });


### PR DESCRIPTION
### Description
Fixes #493; Coerce decimal property values from string to decimal128 at every level of the model definition tree. The decimal properties can be nested in an Array, Object, and any combination of those. Depends on https://github.com/strongloop/loopback-datasource-juggler/pull/1702 for model with property `randomReviews` (Array of decimal properties) to work.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
