### PR TITLE
FIX error Goepoint in replaceById method

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -837,7 +837,7 @@ MongoDB.prototype.updateOrCreate = function updateOrCreate(
       }
 
       if (callback) {
-        callback(err, object, info);
+        callback(err, self.fromDatabase(modelName, object), info);
       }
     }
   );
@@ -1480,6 +1480,7 @@ MongoDB.prototype.replaceWithOptions = function(modelName, id, data, options, cb
   const self = this;
   const idName = self.idName(modelName);
   delete data[idName];
+  data = self.toDatabase(modelName, data);
   this.execute(modelName, 'replaceOne', {_id: id}, data, options, function(
     err,
     info
@@ -1489,7 +1490,7 @@ MongoDB.prototype.replaceWithOptions = function(modelName, id, data, options, cb
     let result;
     const cbInfo = {};
     if (info.result && info.result.n == 1) {
-      result = data;
+      result = self.fromDatabase(modelName, data);
       delete result._id;
       result[idName] = id;
       // create result formats:


### PR DESCRIPTION
FIX: Call fromDatabase in updateOrCreate to handle GeoPoint

### Description
Loopback is using replaceById method in this library to handle the update, but this implementations was not using toDatebasse and fromDatabase to handle GeoPoint type.

I've add some tests to guarantee the fix.

This fix include the Pull Request #426 


#### Related issues

- connect to #472 
- connect to #447
- connect to strongloop/loopback-datasource-juggler#1610 

### Checklist

- [X] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
