### PR TITLE
Show illegal unescaped password error on console

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -310,6 +310,9 @@ MongoDB.prototype.connect = function(callback) {
         self.client = client;
         // The database name might be in the url
         return urlParser(self.settings.url, self.settings, function(err, url) {
+          if (err) {
+            return console.error(err);
+          }
           self.db = client.db(
             url.dbName || self.settings.database,
             url.db_options || self.settings


### PR DESCRIPTION
When the password contains an illegal unescaped character there is no indication that the problem is that, this should indicate the problem and handle the exception

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
