### PR TITLE
fix: ObjectID data type preservation

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -17,6 +17,7 @@ const async = require('async');
 const Connector = require('loopback-connector').Connector;
 const debug = require('debug')('loopback:connector:mongodb');
 const Decimal128 = mongodb.Decimal128;
+const Decimal128TypeRegex = /decimal128/i;
 
 const ObjectIdValueRegex = /^[0-9a-fA-F]{24}$/;
 const ObjectIdTypeRegex = /objectid/i;
@@ -944,13 +945,13 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
       propName = idName;
     }
 
-    const prop = self.getPropertyDefinition(modelName, propName);
-
-    if (prop && prop.mongodb && typeof prop.mongodb.dataType === 'string') {
-      const isDecimal = prop.mongodb.dataType.toLowerCase() === 'decimal128';
-      if (isDecimal) {
+    const propDef = self.getPropertyDefinition(modelName, propName);
+    if (propDef && propDef.mongodb && typeof propDef.mongodb.dataType === 'string') {
+      if (Decimal128TypeRegex.test(propDef.mongodb.dataType)) {
         cond = Decimal128.fromString(cond);
         debug('buildWhere decimal value: %s, constructor name: %s', cond, cond.constructor.name);
+      } else if (isStoredAsObjectID(propDef)) {
+        cond = ObjectID(cond);
       }
     }
 
@@ -974,7 +975,7 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
         cond = [].concat(cond || []);
         query[k] = {
           $in: cond.map(function(x) {
-            if (isObjectIDProperty(modelCtor, prop, x, options))
+            if (isObjectIDProperty(modelCtor, propDef, x, options))
               return ObjectID(x);
             return x;
           }),
@@ -983,7 +984,7 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
         cond = [].concat(cond || []);
         query[k] = {
           $nin: cond.map(function(x) {
-            if (isObjectIDProperty(modelCtor, prop, x, options))
+            if (isObjectIDProperty(modelCtor, propDef, x, options))
               return ObjectID(x);
             return x;
           }),
@@ -1017,7 +1018,7 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
         // Null: 10
         query[k] = {$type: 10};
       } else {
-        if (isObjectIDProperty(modelCtor, prop, cond, options)) {
+        if (isObjectIDProperty(modelCtor, propDef, cond, options)) {
           cond = ObjectID(cond);
         }
         query[k] = cond;
@@ -2101,9 +2102,6 @@ function coercePropertyValue(modelCtor, propValue, propDef, setValue) {
           throw new Error(`${propValue} is not an ObjectID string`);
         }
       }
-    } else if (dataType instanceof ObjectID) {
-      coercedValue = ObjectID(propValue);
-      return setValue(coercedValue);
     }
   } else {
     // Object ID coercibility depends on multiple factors, let coerceToObjectId() handle it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-mongodb",
-  "version": "4.2.0",
+  "version": "5.0.0-1",
   "description": "The official MongoDB connector for the LoopBack framework.",
   "engines": {
     "node": ">=8"
@@ -10,6 +10,7 @@
   "scripts": {
     "benchmarks": "make benchmarks",
     "leak-detection": "make leak-detection",
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
     "test": "mocha test/*.test.js node_modules/juggler-v3/test.js node_modules/juggler-v4/test.js",
     "lint": "eslint .",
     "posttest": "npm run lint"


### PR DESCRIPTION
Preserve ObjectID data type preservation across all properties

### Description

If a property is defined as `ObjectID` type, it is enforced on all the properties on a model.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop/loopback-connector-mongodb/pull/517

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)