### PR TITLE
fix: preserve id on update

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1608,23 +1608,24 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
 
   where = self.buildWhere(modelName, where, options);
 
-  delete data[idName];
-  data = self.toDatabase(modelName, data);
+  let updateData = Object.assign({}, data);
+  delete updateData[idName];
+  updateData = self.toDatabase(modelName, updateData);
 
   // Check for other operators and sanitize the data obj
-  data = self.parseUpdateData(modelName, data, options);
+  updateData = self.parseUpdateData(modelName, updateData, options);
 
   this.execute(
     modelName,
     'updateMany',
     where,
-    data,
+    updateData,
     {upsert: false},
     function(err, info) {
       if (err) return cb && cb(err);
 
       if (self.debug)
-        debug('updateAll.callback', modelName, where, data, err, info);
+        debug('updateAll.callback', modelName, where, updateData, err, info);
 
       const affectedCount = info.result ? info.result.n : undefined;
 

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -1032,6 +1032,27 @@ describe('mongodb connector', function() {
   });
 
   describe('updateAll', function() {
+    it('should not mutate the input data object', async function() {
+      const user = await User.create({name: 'Al', age: 31, email: 'al@strongloop'});
+      const userId = user.id;
+      const userData = user.toObject();
+      userData.age = 100;
+
+      await User.update(userData);
+      userData.should.have.property('id', userId);
+    });
+
+    it('should not mutate the input model instance', async function() {
+      const user = await User.create({name: 'Al', age: 31, email: 'al@strongloop'});
+      const userId = user.id;
+      user.age = 100;
+      user.name = 'Albert';
+
+      await User.update(user);
+      user.should.have.property('id', userId);
+      user.should.have.property('name', 'Albert');
+    });
+
     it('should update the instance matching criteria', function(done) {
       User.create({name: 'Al', age: 31, email: 'al@strongloop'}, function(
         err1,


### PR DESCRIPTION
Leave the id property alone on update. 

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.com/strongloop/loopback-next/issues/3267

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
