### PR TITLE
Implicit null type

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -937,6 +937,11 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
 
   where = sanitizeFilter(where, options);
 
+  let implicitNullType = false;
+  if (this.settings.hasOwnProperty('implicitNullType')) {
+    implicitNullType = !!this.settings.implicitNullType;
+  }
+
   const idName = self.idName(modelName);
   Object.keys(where).forEach(function(k) {
     let cond = where[k];
@@ -1026,7 +1031,7 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
         query[k]['$' + spec] = cond;
       }
     } else {
-      if (cond === null) {
+      if (cond === null && !implicitNullType) {
         // http://docs.mongodb.org/manual/reference/operator/query/type/
         // Null: 10
         query[k] = {$type: 10};

--- a/test/connector-functions.test.js
+++ b/test/connector-functions.test.js
@@ -31,3 +31,43 @@ describe('connector function - findById', function() {
     });
   });
 });
+
+describe('find (implicitNullType)', function() {
+  let db, TestAlias, sampleId;
+  let implicitNullType=false
+  beforeEach(function(done) {
+    db = global.getDataSource({
+      host: '127.0.0.1',
+      port: global.config.port,
+      implicitNullType,
+    });
+    implicitNullType = !implicitNullType
+    TestAlias = db.define('TestAlias', {foo: {type: String}});
+    db.automigrate(function(err) {
+      if (err) return done(err);
+      TestAlias.create({foo: 'foo'}, function(err, t) {
+        if (err) return done(err);
+        sampleId = t.id;
+        done();
+      });
+    });
+  });
+
+  it('find none by id: sampleId, deletedAt: null (implicitNullType=false)', function(done) {
+    db.connector.all('TestAlias', {where: {id: sampleId, deletedAt: null}}, {}, function(err, r) {
+      if (err) return done(err);
+      if (r.length) {
+        return done(new Error('all should not have found the TestAlias document'))
+      }
+      done();
+    });
+  });
+
+  it('find all by id: sampleId, deletedAt: null (implicitNullType=true)', function(done) {
+    db.connector.all('TestAlias', {where: {id: sampleId, deletedAt: null}}, {}, function(err, r) {
+      if (err) return done(err);
+      r[0].foo.should.equal('foo');
+      done();
+    });
+  });
+});

--- a/test/connector-functions.test.js
+++ b/test/connector-functions.test.js
@@ -34,14 +34,14 @@ describe('connector function - findById', function() {
 
 describe('find (implicitNullType)', function() {
   let db, TestAlias, sampleId;
-  let implicitNullType=false
+  let implicitNullType = false;
   beforeEach(function(done) {
     db = global.getDataSource({
       host: '127.0.0.1',
       port: global.config.port,
       implicitNullType,
     });
-    implicitNullType = !implicitNullType
+    implicitNullType = !implicitNullType;
     TestAlias = db.define('TestAlias', {foo: {type: String}});
     db.automigrate(function(err) {
       if (err) return done(err);
@@ -57,7 +57,7 @@ describe('find (implicitNullType)', function() {
     db.connector.all('TestAlias', {where: {id: sampleId, deletedAt: null}}, {}, function(err, r) {
       if (err) return done(err);
       if (r.length) {
-        return done(new Error('all should not have found the TestAlias document'))
+        return done(new Error('all should not have found the TestAlias document'));
       }
       done();
     });


### PR DESCRIPTION
### Description

added implicitNullType boolean to connector.settings

default false to prevent breaking changes

when true it allows the connector not to replace null by {$type:10} in where clause

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
