### PR TITLE
ObjectID Coercion supports array of values

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1965,7 +1965,7 @@ function coerceToObjectId(modelCtor, propDef, propValue) {
  */
 function isObjectIDProperty(modelCtor, propDef, value, options) {
   if (!propDef) return false;
-
+  if (Array.isArray(value)) return isObjectIDProperty(modelCtor, propDef, value[0], options);
   if (typeof value === 'string' && value.match(ObjectIdValueRegex)) {
     if (isStoredAsObjectID(propDef)) return true;
     else return !isStrictObjectIDCoercionEnabled(modelCtor, options);
@@ -2130,17 +2130,26 @@ function coercePropertyValue(modelCtor, propValue, propDef, setValue) {
           return setValue(coercedValue);
         }
       } else if (typeIsObjectId(dataType)) {
-        if (isObjectIDProperty(modelCtor, propDef, propValue)) {
-          coercedValue = ObjectID(propValue);
-          return setValue(coercedValue);
-        } else {
-          throw new Error(`${propValue} is not an ObjectID string`);
-        }
+        const isArray = Array.isArray(propValue);
+        let propArr = isArray ? propValue : [propValue];
+        propArr = propArr.map((arrElem) => {
+          if (isObjectIDProperty(modelCtor, propDef, arrElem)) {
+            return ObjectID(arrElem);
+          } else {
+            throw new Error(`${propValue} is not an ObjectID string`);
+          }
+        });
+        coercedValue = isArray ? propArr : propArr[0];
+        return setValue(coercedValue);
       }
     }
   } else {
     // Object ID coercibility depends on multiple factors, let coerceToObjectId() handle it
-    propValue = coerceToObjectId(modelCtor, propDef, propValue);
+    if (Array.isArray(propValue)) {
+      propValue = propValue.map(elem => coerceToObjectId(modelCtor, propDef, elem));
+    } else {
+      propValue = coerceToObjectId(modelCtor, propDef, propValue);
+    }
     setValue(propValue);
   }
 }

--- a/test/objectid.test.js
+++ b/test/objectid.test.js
@@ -104,6 +104,7 @@ describe('ObjectID', function() {
       'ArticleC',
       {
         xid: {type: String, mongodb: {dataType: 'objectid'}},
+        xidArr: {type: [String], mongodb: {dataType: 'objectid'}},
         title: String,
       },
       {strictObjectIDCoercion: true},
@@ -127,6 +128,16 @@ describe('ObjectID', function() {
       found.xid.should.be.an.instanceOf(ds.ObjectID);
     });
 
+    it('should properly save an array of ObjectIDs', async () => {
+      await Article.create({
+        xid: objectIDLikeString,
+        xidArr: [objectIDLikeString],
+        title: 'abcWithArr',
+      });
+      const found = await Article.findOne({where: {title: 'abcWithArr'}});
+      found.xidArr.should.be.an.Array().which.containDeep([new ds.ObjectID(objectIDLikeString)]);
+    });
+
     it('handles auto-generated PK properties defined in LB4 style', async () => {
       const Note = ds.createModel('NoteLB4', {
         id: {
@@ -143,6 +154,38 @@ describe('ObjectID', function() {
 
       const result = await Note.create({title: 'hello'});
       // the test passes when this call does not throw
+    });
+  });
+
+  context('ObjectID as a constructor', function() {
+    const Article = ds.createModel(
+      'ArticleC2',
+      {
+        xid: {type: ds.ObjectID},
+        xidArr: {type: [ds.ObjectID]},
+        title: String,
+      },
+      {strictObjectIDCoercion: true},
+    );
+
+    beforeEach(function(done) {
+      Article.deleteAll(done);
+    });
+
+    it('should save as ObjectID regardless of strictObjectIDCoercion: true', async function() {
+      await Article.create({xid: objectIDLikeString, title: 'abc'});
+      const found = await Article.findOne({where: {title: 'abc'}});
+      found.xid.should.be.an.instanceOf(ds.ObjectID);
+    });
+
+    it('should properly save an array of ObjectIDs', async () => {
+      await Article.create({
+        xid: objectIDLikeString,
+        xidArr: [objectIDLikeString],
+        title: 'abcWithArr',
+      });
+      const found = await Article.findOne({where: {title: 'abcWithArr'}});
+      found.xidArr.should.be.an.Array().which.containDeep([new ds.ObjectID(objectIDLikeString)]);
     });
   });
 });


### PR DESCRIPTION
### Description

When a property is of type array of 'ObjectId', it now properly is coerced.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->
- fixes #545 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
