### PR TITLE
fix creation of LB4 models with auto-generated id

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -596,7 +596,13 @@ MongoDB.prototype.create = function(modelName, data, options, callback) {
       return callback(err);
     }
     idValue = result.ops[0]._id;
-    idValue = self.coerceId(modelName, idValue, options);
+
+    try {
+      idValue = self.coerceId(modelName, idValue, options);
+    } catch (err) {
+      return callback(err);
+    }
+
     // Wrap it to process.nextTick as delete data._id seems to be interferring
     // with mongo insert
     process.nextTick(function() {
@@ -1963,7 +1969,7 @@ function isObjectIDProperty(modelCtor, propDef, value, options) {
   if (typeof value === 'string' && value.match(ObjectIdValueRegex)) {
     if (isStoredAsObjectID(propDef)) return true;
     else return !isStrictObjectIDCoercionEnabled(modelCtor, options);
-  } else if (value instanceof ObjectID) {
+  } else if (value instanceof mongodb.ObjectID) {
     return true;
   } else {
     return false;

--- a/test/objectid.test.js
+++ b/test/objectid.test.js
@@ -126,5 +126,23 @@ describe('ObjectID', function() {
       const found = await Article.findOne({where: {title: 'abc'}});
       found.xid.should.be.an.instanceOf(ds.ObjectID);
     });
+
+    it('handles auto-generated PK properties defined in LB4 style', async () => {
+      const Note = ds.createModel('NoteLB4', {
+        id: {
+          type: 'string',
+          id: true,
+          generated: true,
+          mongodb: {dataType: 'ObjectID'},
+        },
+        title: {
+          type: 'string',
+          required: true,
+        },
+      });
+
+      const result = await Note.create({title: 'hello'});
+      // the test passes when this call does not throw
+    });
   });
 });


### PR DESCRIPTION
- Add a try/catch block to prevent `coerceId` from crashing the process on uncaught exception (forward the coercion error via callback).

- Fix `isObjectIDProperty` to use the correct ObjectID constructor in `instanceof` check.

This fixes the problem described in https://github.com/strongloop/loopback-next/issues/4059#issuecomment-557138697.

<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mongodb) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
