### PR TITLE
Atomic upsertWithWhere

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1695,6 +1695,77 @@ MongoDB.prototype.update = MongoDB.prototype.updateAll = function updateAll(
   );
 };
 
+MongoDB.prototype.upsertWithWhere = function upsertWithWhere(
+  modelName,
+  where,
+  data,
+  options,
+  cb,
+) {
+  const self = this;
+
+  if (self.debug) {
+    debug('upsertWithWhere', modelName, where, data);
+  }
+
+  let updateData = Object.assign({}, data);
+
+  const idValue = self.getIdValue(modelName, updateData);
+  const idName = self.idName(modelName);
+
+  where = self.buildWhere(modelName, where, options);
+
+  if (idValue === null || idValue === undefined) {
+    delete updateData[idName]; // Allow MongoDB to generate the id
+  } else {
+    const oid = self.coerceId(modelName, idValue, options); // Is it an Object ID?c
+    updateData._id = oid; // Set it to _id
+    if (idName !== '_id') {
+      delete updateData[idName];
+    }
+  }
+
+  updateData = self.toDatabase(modelName, updateData);
+
+  // Check for other operators and sanitize the data obj
+  updateData = self.parseUpdateData(modelName, updateData, options);
+
+  this.execute(
+    modelName,
+    'findOneAndUpdate',
+    where,
+    updateData,
+    {
+      upsert: true,
+      returnOriginal: false,
+      sort: [['_id', 'asc']],
+    },
+    function(err, result) {
+      if (err) return cb && cb(err);
+
+      if (self.debug)
+        debug('upsertWithWhere.callback', modelName, where, updateData, err, result);
+
+      const object = result && result.value;
+      self.setIdValue(modelName, object, object._id);
+      if (object && idName !== '_id') {
+        delete object._id;
+      }
+
+      let info;
+      if (result && result.lastErrorObject) {
+        info = {isNewInstance: !result.lastErrorObject.updatedExisting};
+      } else {
+        debug('upsertWithWhere result format not recognized: %j', result);
+      }
+
+      if (cb) {
+        cb(err, self.fromDatabase(modelName, object), info);
+      }
+    },
+  );
+};
+
 /**
  * Disconnect from MongoDB
  */

--- a/test/init.js
+++ b/test/init.js
@@ -47,4 +47,5 @@ global.connectorCapabilities = {
   ilike: false,
   nilike: false,
   nestedProperty: true,
+  atomicUpsertWithWhere: true,
 };


### PR DESCRIPTION
Implement atomic upsertWithWhere method.

The out-of-the-box implementation catch error if multiple instances are founds.
With atomic implementation one test present in the juggler datasource will be disabled.
I added a new option to specify if connector has an atomic implementation. See https://github.com/strongloop/loopback-datasource-juggler/pull/1864.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mongodb) 👈

- [x] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
