### PR TITLE
fix: coerce property value defined as array of ObjectID

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -2151,12 +2151,12 @@ function coercePropertyValue(modelCtor, propValue, propDef, setValue) {
         if (Array.isArray(propValue)) {
           propValue = propValue.map(val => {
             if (isObjectIDProperty(modelCtor, propDef, val)) {
-              return coercedValue = ObjectID(propValue);
+              return coercedValue = ObjectID(val);
             } else {
               throw new Error(`${val} is not an ObjectID string`);
             }
           });
-          return setValue(coercedValue);
+          return setValue(propValue);
         } else if (isObjectIDProperty(modelCtor, propDef, propValue)) {
           coercedValue = ObjectID(propValue);
           return setValue(coercedValue);

--- a/test/objectid.test.js
+++ b/test/objectid.test.js
@@ -10,6 +10,7 @@ require('./init.js');
 let Book, Chapter;
 const ds = global.getDataSource();
 const objectIDLikeString = '7cd2ad46ffc580ba45d3cb1f';
+const objectIDLikeString2 = '7cd2ad46ffc580ba45d3cb1e';
 
 describe('ObjectID', function() {
   before(function() {
@@ -131,11 +132,15 @@ describe('ObjectID', function() {
     it('should properly save an array of ObjectIDs', async () => {
       await Article.create({
         xid: objectIDLikeString,
-        xidArr: [objectIDLikeString],
+        xidArr: [objectIDLikeString, objectIDLikeString2],
         title: 'arrayOfObjectID',
       });
       const found = await Article.findOne({where: {title: 'arrayOfObjectID'}});
-      found.xidArr.should.be.an.Array().which.containDeep([new ds.ObjectID(objectIDLikeString)]);
+      // the type of the returned array is actually string even it's stored as ObjectIds in the db as expected
+      found.xidArr.should.be.an.Array().which.containDeep([
+        new ds.ObjectID(objectIDLikeString),
+        new ds.ObjectID(objectIDLikeString2),
+      ]);
     });
 
     it('handles auto-generated PK properties defined in LB4 style', async () => {


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

Fixes https://github.com/strongloop/loopback-next/issues/5848 : failed to set array of strings to ObjectId with `dataType: objectid`.
## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mongodb) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
