### PR TITLE
fix: sanitizes extra dollar signs for operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you run a MongoDB with authentification ([Docker's example here](https://gith
       <td>allowExtendedOperators</td>
       <td>Boolean</td>
       <td><code>false</code></td>
-      <td>Set to <code>true</code> to enable using MongoDB operators such as <code>$currentDate, $inc, $max, $min, $mul, $rename, $setOnInsert, $set, $unset, $addToSet, $pop, $pullAll, $pull, $pushAll, $push</code>, and <code>$bit</code>.</td>
+      <td>Set to <code>true</code> to enable using MongoDB operators such as <code>$currentDate, $inc, $max, $min, $mul, $rename, $setOnInsert, $set, $unset, $addToSet, $pop, $pullAll, $pull, $push</code>, and <code>$bit</code>. See <a href="https://loopback.io/doc/en/lb4/MongoDB-connector.html#update-operators" class="external-link" rel="nofollow">Update Operators</a> section below</td>
     </tr>
     <tr>
       <td>enableGeoIndexing</td>
@@ -248,6 +248,32 @@ The .loopbackrc file is in JSON format, for example:
 **Note**: user/password is only required if the MongoDB server has authentication enabled. `"authSource"` should be used if you cannot log in to your database using your credentials.
 
 </details>
+
+## Update Operators
+
+Except the comparison and logical operators LoopBack supports in the [operator list](https://loopback.io/doc/en/lb4/Where-filter.html#operators) of `Where` filter, you can also enable [MongoDB update operators](https://docs.mongodb.com/manual/reference/operator/update/) for `update*` methods by setting the flag `allowExtendedOperators` to `true` in the datasource configuration.
+
+Here is an example of updating the price for all the products under category `furniture` if their current price is lower than 100:
+
+```
+await productRepo.updateAll({ $max: { price: 100 }}, { category: {eq: 'furniture'} // where clause goes in here });
+```
+
+<details><summary markdown="span"><strong>For LoopBack 3 users</strong></summary>
+
+```
+Product.updateAll(
+            { category: {eq: 'furniture'} // where clause goes in here },
+            {$max: {price: 100}},
+            options,
+            function(err, updateproducts) {
+           ...
+```
+
+</details>
+
+{% include tip.html content="you **will not** need the dollar sign `'$'` for operators in the Where
+clause." %}
 
 ## Handling ObjectId
 

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -765,7 +765,6 @@ MongoDB.prototype.parseUpdateData = function(modelName, data, options) {
       '$pop',
       '$pullAll',
       '$pull',
-      '$pushAll',
       '$push',
       // Bitwise operator
       '$bit',
@@ -993,6 +992,7 @@ MongoDB.prototype.buildWhere = function(modelName, where, options) {
     const modelCtor = self._models[modelName];
 
     if (spec) {
+      spec = trimLeadingDollarSigns(spec);
       if (spec === 'between') {
         query[k] = {$gte: cond[0], $lte: cond[1]};
       } else if (spec === 'inq') {
@@ -1993,6 +1993,17 @@ function isObjectIDProperty(modelCtor, propDef, value, options) {
     return false;
   }
 }
+
+/**
+ * Removes extra dollar sign '$' for operators
+ *
+ * @param {*} spec the operator for Where filter
+ */
+function trimLeadingDollarSigns(spec) {
+  return spec.replace(/^(\$)+/, '');
+}
+
+exports.trimLeadingDollarSigns = trimLeadingDollarSigns;
 
 function sanitizeFilter(filter, options) {
   options = Object.assign({}, options);

--- a/test/mongodb.test.js
+++ b/test/mongodb.test.js
@@ -12,6 +12,7 @@ const testUtils = require('../lib/test-utils');
 const async = require('async');
 const sinon = require('sinon');
 const sanitizeFilter = require('../lib/mongodb').sanitizeFilter;
+const trimLeadingDollarSigns = require('../lib/mongodb').trimLeadingDollarSigns;
 
 const GeoPoint = require('loopback-datasource-juggler').GeoPoint;
 
@@ -1485,7 +1486,7 @@ describe('mongodb connector', function() {
                 should.not.exist(err);
                 updatedusers.should.have.property('count', 1);
 
-                User.find({where: {name: 'Simon'}}, function(
+                User.find({where: {name: {$eq: 'Simon'}}}, function(
                   err,
                   foundusers,
                 ) {
@@ -3726,6 +3727,29 @@ describe('mongodb connector', function() {
     });
   });
 
+  context('trimLeadingDollarSigns', () =>{
+    it('removes an extra leading dollar sign in ths operators', () => {
+      const spec = '$eq';
+      const updatedSpec = trimLeadingDollarSigns(spec);
+      updatedSpec.should.equal('eq');
+    });
+    it('removes extra leading dollar signs in ths operators', () => {
+      const spec = '$$eq';
+      const updatedSpec = trimLeadingDollarSigns(spec);
+      updatedSpec.should.equal('eq');
+    });
+
+    it('remains the same if the input does not contain any dollar signs', () => {
+      const spec = 'eq';
+      const updatedSpec = trimLeadingDollarSigns(spec);
+      updatedSpec.should.equal(spec);
+    });
+    it('remains the same if the input does not start with dollar signs', () => {
+      const spec = 'eq$';
+      const updatedSpec = trimLeadingDollarSigns(spec);
+      updatedSpec.should.equal(spec);
+    });
+  });
   context('sanitizeFilter()', () => {
     it('returns filter if not an object', () => {
       const input = false;


### PR DESCRIPTION
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

fixes https://github.com/strongloop/loopback-connector-mongodb/issues/532

Add a helper function that removes **all** extra dollar signs.
e.g `$eq` -> `eq`, `$$eq` -> `eq` ( don't consider the case as an error). 

<img width="793" alt="Screen Shot 2020-07-07 at 16 33 12" src="https://user-images.githubusercontent.com/50331796/86840759-1d156400-c071-11ea-8736-02de8932cd90.png">


## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mongodb) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
