### PR TITLE
chore: add Node.js 14 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
   - "10"
   - "12"
-  - "13"
+  - "14"
 
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
Related to https://github.com/strongloop/loopback-next/issues/6021

Remove Node.js 13 and add Node.js 14 to `.travis.yml`.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/loopback-connector-mongodb) 👈

- [ ] `npm test` passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
