### PR TITLE
Update mongodb to ^3.6.4

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -105,6 +105,13 @@ exports.initialize = function initializeDataSource(dataSource, callback) {
 
   s.safe = s.safe !== false;
   s.w = s.w || 1;
+  s.writeConcern = s.writeConcern || {
+    w: s.w,
+    wtimeout: s.wtimeout || null,
+    j: s.j || null,
+    journal: s.journal || null,
+    fsync: s.fsync || null,
+  };
   s.url = s.url || generateMongoDBURL(s);
   s.useNewUrlParser = s.useNewUrlParser !== false;
   s.useUnifiedTopology = s.useUnifiedTopology !== false;
@@ -251,9 +258,6 @@ MongoDB.prototype.connect = function(callback) {
       'acceptableLatencyMS',
       'connectWithNoPrimary',
       'authSource',
-      'w',
-      'wtimeout',
-      'j',
       'forceServerObjectId',
       'serializeFunctions',
       'ignoreUndefined',
@@ -278,13 +282,13 @@ MongoDB.prototype.connect = function(callback) {
       'password',
       'authMechanism',
       'compression',
-      'fsync',
       'readPreferenceTags',
       'numberOfRetries',
       'auto_reconnect',
       'minSize',
       'useNewUrlParser',
       'useUnifiedTopology',
+      'writeConcern',
       // Ignored options
       'native_parser',
       // Legacy options
@@ -293,6 +297,11 @@ MongoDB.prototype.connect = function(callback) {
       'replSet',
       'mongos',
       'db',
+      'w',
+      'wtimeout',
+      'j',
+      'journal',
+      'fsync',
     ];
 
     const lbOptions = Object.keys(self.settings);


### PR DESCRIPTION
Signed-off-by: wolrajhti <pierre.bouteloup@hotmail.fr>

Since 3.6.4 mongodb driver `console.warn` over and over a depreciation message related to the new format for WriteConcern options. This PR add support for new format, while keeping backward compatibility.

(There is an opened issue for the mongodb driver, https://jira.mongodb.org/browse/NODE-3114, so this PR alone will not disable all   ##console.warn).

## Related issue
#616 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
