### PR TITLE
package.json: set publish tag to `lts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "loopback-connector-mongodb",
   "version": "5.5.0",
+  "publishConfig": {
+    "tag": "lts"
+  },
   "description": "The official MongoDB connector for the LoopBack framework.",
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Prevent future 5.x releases to be published as `latest`, which would cause users to download a 5.x version when running `npm install loopback-connector-mongodb`.

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
