### PR TITLE
fix: include options parameter in createIndex method

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -2228,7 +2228,7 @@ MongoDB.prototype.autoupdate = function(models, cb) {
               debug('createIndex: ', index);
             }
             const callbackCreateIndex = util.callbackify(() => self
-              .collection(modelName).createIndex(index.fields || index.keys));
+              .collection(modelName).createIndex(index.fields || index.keys, index.options));
             callbackCreateIndex(indexCallback);
           },
           modelCallback,


### PR DESCRIPTION
**Problem:** When defining custom index names in model settings, the connector was ignoring the specified `name` option and falling back to MongoDB's default naming convention (e.g., "archived_1" instead of "archived").

**Root Cause:** The `createIndex()` call was missing the `options` parameter, so custom index options including the `name` field were not being passed to MongoDB.

**Solution:** Updated the `createIndex()` call to include the `index.options` parameter:

## Checklist

- [X] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine (fails 1 test but this is unrelated)
- [ ] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [X] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
