### PR TITLE
fix: #900 replace callback implementation by the promise one

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -2349,23 +2349,17 @@ MongoDB.prototype.beginTransaction = function(isolationLevel, cb) {
 };
 
 MongoDB.prototype.commit = function(tx, cb) {
-  tx.commitTransaction(function(err) {
-    tx.endSession(null, function(error) {
-      if (err) return cb(err);
-      if (error) return cb(error);
-      cb();
-    });
-  });
+  tx.commitTransaction()
+    .then(() => tx.endSession())
+    .then(() => cb())
+    .catch((err) => cb(err));
 };
 
 MongoDB.prototype.rollback = function(tx, cb) {
-  tx.abortTransaction(function(err) {
-    tx.endSession(null, function(error) {
-      if (err) return cb(err);
-      if (error) return cb(error);
-      cb();
-    });
-  });
+  tx.abortTransaction()
+    .then(() => tx.endSession())
+    .then(() => cb())
+    .catch((err) => cb(err));
 };
 
 function isInTransation(options) {


### PR DESCRIPTION
Starting from version 5, the mongodb node driver removed callback support in favor of promises only. This PR fixes the commit and rollback implementation of the connector.
No extra test needed. It is already covered by the transaction one (that is skipped...).

Fixes #900 

## Checklist

- [x] DCO (Developer Certificate of Origin) [signed in all commits](https://loopback.io/doc/en/contrib/code-contrib.html)
- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
